### PR TITLE
Add the feature to manually (not with autolayout) add alias nodes

### DIFF
--- a/docs/api_reference/c_api_index.rst
+++ b/docs/api_reference/c_api_index.rst
@@ -41,6 +41,8 @@ Functions
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_createDefaultLayoutLocations(SBMLDocument* document, const int maxNumConnectedEdges = 3, bool useNameAsTextLabel= true, bool resetLockedNodes = false, const char** lockedNodeIds = NULL, const int lockedNodesSize = 0)
 
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_createAliasSpeciesGlyph(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex, int layoutIndex)
+
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_getCanvasWidth(SBMLDocument* document, int layoutIndex = 0)
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::c_api_setCanvasWidth(SBMLDocument* document, const double width, int layoutIndex = 0)

--- a/docs/api_reference/cpp_api_index.rst
+++ b/docs/api_reference/cpp_api_index.rst
@@ -114,6 +114,10 @@ Layout Functions
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::updateLayoutCurves(SBMLDocument* document, Layout* layout)
 
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex)
+
+.. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex)
+
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::getDimensions(SBMLDocument* document, unsigned int layoutIndex = 0)
 
 .. doxygenfunction:: LIBSBMLNETWORK_CPP_NAMESPACE::getDimensionWidth(SBMLDocument* document, unsigned int layoutIndex = 0)

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -401,6 +401,23 @@ class LibSBMLNetwork:
 
         return lib.c_api_createDefaultLayoutLocations(self.sbml_object, locked_nodes_ptr, len(locked_nodes))
 
+    def createAliasSpeciesGlyph(self, species_id, reaction_id, reaction_glyph_index=0, layout_index=0):
+        """
+        Creates an alias SpeciesGlyph of Species with the given species_id for the ReactionGlyph with the given reaction_id and reaction_glyph_index in the Layout object with the given index in the given SBMLDocument
+
+        :Parameters:
+
+            - species_id (string): a string that determines the id of the Species
+            - reaction_id (string): a string that determines the id of the Reaction
+            - reaction_glyph_index (int, optional): an integer (default: 0) that determines the index of the ReactionGlyph in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true on success and false if the alias SpeciesGlyph could not be created
+        """
+        return lib.c_api_createAliasSpeciesGlyph(self.sbml_object, str(species_id).encode(), str(reaction_id).encode(), reaction_glyph_index, layout_index)
+
     def getCanvasWidth(self, layout_index=0):
         """
         Returns the width of the canvas of the Layout object with the given index in the given SBMLDocument

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -117,6 +117,10 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return createDefaultLayoutLocations(document, maxNumConnectedEdges, useNameAsTextLabel, resetLockedNodes, lockedNodesSet);
     }
 
+    int c_api_createAliasSpeciesGlyph(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex, int layoutIndex) {
+        return createAliasSpeciesGlyph(document, layoutIndex, speciesId, reactionId, reactionGlyphIndex);
+    }
+
     double c_api_getCanvasWidth(SBMLDocument* document, int layoutIndex) {
         return getDimensionWidth(document, layoutIndex);
     }

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -125,6 +125,15 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     LIBSBMLNETWORK_EXTERN int c_api_createDefaultLayoutLocations(SBMLDocument* document, const int maxNumConnectedEdges = 3, bool useNameAsTextLabel= true,
                                                                bool resetLockedNodes = false, const char*** lockedNodeIds = NULL, const int lockedNodesSize = 0);
 
+    /// @brief Create an alias SpeciesGlyph object for Species with the given id and connect all the SpeciesReferenceGlyphs in the ReactionGlyph object with the given id and index that contain Species as a participant to the alias SpeciesGlyph in the Layout object with the given index in the ListOfLayouts of the SBMLDocument.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param speciesId the id of the species to create an alias SpeciesGlyph for.
+    /// @param reactionId the id of the reaction to create an alias SpeciesGlyph for.
+    /// @param reactionGlyphIndex the index of the ReactionGlyph object.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return integer value indicating success/failure of the function.
+    LIBSBMLNETWORK_EXTERN int c_api_createAliasSpeciesGlyph(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex, int layoutIndex);
+
     /// @brief Returns the value of the "width" attribute of the Dimensions object of the Layout object
     /// with the given index in the ListOfLayouts of the SBML document.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_layout.cpp
+++ b/src/libsbmlnetwork_layout.cpp
@@ -305,7 +305,7 @@ std::vector<SpeciesReferenceGlyph*> getSpeciesReferenceGlyphs(Layout* layout, co
 
 std::vector<SpeciesReferenceGlyph*> getSpeciesReferenceGlyphs(GraphicalObject* reactionGlyph) {
     if (isReactionGlyph(reactionGlyph))
-        return getAssociatedSpeciesReferenceGlyphsWithReactionGlyph((ReactionGlyph*)reactionGlyph);
+        return getSpeciesReferenceGlyphs((ReactionGlyph*)reactionGlyph);
 
     return std::vector<SpeciesReferenceGlyph*>();
 }

--- a/src/libsbmlnetwork_layout_helpers.h
+++ b/src/libsbmlnetwork_layout_helpers.h
@@ -100,11 +100,25 @@ SpeciesReferenceGlyph* createDummySpeciesReferenceGlyph(Layout* layout, Reaction
 
 void setAliasSpeciesGlyphs(Layout* layout, const int maxNumConnectedEdges, const std::vector<std::map<std::string, std::string>>& userData = {});
 
+int createAliasSpeciesGlyphs(Layout* layout, SpeciesGlyph* speciesGlyph, std::vector<SpeciesReferenceGlyph*> speciesGlyphReferences, const int maxNumConnectedEdges, const int numRequiredAliasSpeciesGlyphs, const std::vector<std::map<std::string, std::string>>& userData = {});
+
+int createAliasSpeciesGlyph(Layout* layout, const std::string speciesId, ReactionGlyph* reactionGlyph);
+
+SpeciesGlyph* createAliasSpeciesGlyph(Layout* layout, const std::string& speciesId);
+
+SpeciesGlyph* createAliasSpeciesGlyph(Layout* layout, const std::string& speciesId, std::vector<SpeciesReferenceGlyph*> speciesGlyphReferences);
+
+const bool canHaveAlias(Layout* layout, std::vector<SpeciesReferenceGlyph*> connectedSpeciesGlyphReferencesOfReactionGlyph);
+
+void setAliasSpeciesGlyphPosition(SpeciesGlyph* aliasSpeciesGlyph, ReactionGlyph* reactionGlyph);
+
+void setAliasSpeciesGlyphDimensions(SpeciesGlyph* aliasSpeciesGlyph);
+
+void setAliasSpeciesGlyphTextGlyph(Layout* layout, SpeciesGlyph* aliasSpeciesGlyph);
+
 std::vector<SpeciesReferenceGlyph*> getConnectedSpeciesGlyphReferences(Layout* layout, SpeciesGlyph* speciesGlyph);
 
 int getNumRequiredAliasSpeciesGlyphs(const int numConnectedEdges, const int maxNumConnectedEdges);
-
-void createAliasSpeciesGlyphs(Layout* layout, SpeciesGlyph* speciesGlyph, std::vector<SpeciesReferenceGlyph*> speciesGlyphReferences, const int maxNumConnectedEdges, const int numRequiredAliasSpeciesGlyphs, const std::vector<std::map<std::string, std::string>>& userData = {});
 
 void setTextGlyphs(Layout* layout);
 
@@ -133,6 +147,8 @@ SpeciesReferenceGlyph* createAssociatedSpeciesReferenceGlyph(Layout* layout, Rea
 const int getNumSpeciesReferencesAssociatedWithSpecies(Reaction* reaction, const std::string& speciesId);
 
 const int getNumSpeciesReferencesGlyphsAssociatedWithSpecies(Layout* layout, ReactionGlyph* reactionGlyph, const std::string& speciesId);
+
+std::vector<SpeciesReferenceGlyph*> getSpeciesReferencesAssociatedWithSpecies(Layout* layout, ReactionGlyph* reactionGlyph, const std::string& speciesId);
 
 TextGlyph* createAssociatedTextGlyph(Layout* layout, GraphicalObject* graphicalObject);
 
@@ -192,9 +208,11 @@ std::vector<ReactionGlyph*> getAssociatedReactionGlyphsWithReactionId(Layout* la
 
 std::vector<SpeciesReferenceGlyph*> getSpeciesReferenceGlyphs(ReactionGlyph* reactionGlyph);
 
-std::vector<SpeciesReferenceGlyph*> getAssociatedSpeciesReferenceGlyphsWithReactionGlyph(ReactionGlyph* reactionGlyph);
-
 const std::string getTextGlyphUniqueId(Layout* layout, GraphicalObject* graphicalObject);
+
+const std::string getAliasSpeciesGlyphId(Layout* layout, const std::string speciesId);
+
+const std::string getIdOfSpeciesReferenceGlyphConnectedToAliasSpeciesGlyph(std::string speciesReferenceGlyphId, const std::string& originalSpeciesGlyphId, const std::string& aliasSpeciesGlyphId);
 
 const bool layoutContainsGlyphs(Layout* layout);
 

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -129,6 +129,20 @@ int createDefaultLayoutLocations(SBMLDocument* document, const int maxNumConnect
     return setDefaultLayoutLocations(document, layout, maxNumConnectedEdges, useNameAsTextLabel, resetLockedNodes, lockedNodesSet);
 }
 
+int createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex) {
+    if (!createAliasSpeciesGlyph(getLayout(document), speciesId, getReactionGlyph(document, reactionId, reactionGlyphIndex)))
+        return updateLayoutCurves(document, getLayout(document));
+
+    return -1;
+}
+
+int createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex) {
+    if (!createAliasSpeciesGlyph(getLayout(document, layoutIndex), speciesId, getReactionGlyph(document, reactionId, reactionGlyphIndex)))
+        return updateLayoutCurves(document, getLayout(document, layoutIndex));
+
+    return -1;
+}
+
 Dimensions* getDimensions(SBMLDocument* document, unsigned int layoutIndex) {
     return getDimensions(getLayout(document, layoutIndex));
 }

--- a/src/libsbmlnetwork_sbmldocument_layout.h
+++ b/src/libsbmlnetwork_sbmldocument_layout.h
@@ -78,6 +78,23 @@ LIBSBMLNETWORK_EXTERN int createDefaultLayoutFeatures(SBMLDocument* document, co
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int updateLayoutCurves(SBMLDocument* document, Layout* layout);
 
+/// @brief Create an alias SpeciesGlyph object for Species with the given id and connect all the SpeciesReferenceGlyphs in the ReactionGlyph object with the given id and index that contain Species as a participant to the alias SpeciesGlyph in the first Layout object in the ListOfLayouts of the SBMLDocument.
+/// @param document a pointer to the SBMLDocument object.
+/// @param speciesId the id of the Species to create an alias SpeciesGlyph for.
+/// @param reactionId the id of the Reaction to create an alias SpeciesGlyph for.
+/// @param reactionGlyphIndex the index of the ReactionGlyph object to create an alias SpeciesGlyph for.
+/// @return integer value indicating success/failure of the function.
+LIBSBMLNETWORK_EXTERN int createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex);
+
+/// @brief Create an alias SpeciesGlyph object for Species with the given id and connect all the SpeciesReferenceGlyphs in the ReactionGlyph object with the given id and index that contain Species as a participant to the alias SpeciesGlyph in the Layout object with the given index in the ListOfLayouts of the SBMLDocument.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout to return.
+/// @param speciesId the id of the Species to create an alias SpeciesGlyph for.
+/// @param reactionId the id of the Reaction to create an alias SpeciesGlyph for.
+/// @param reactionGlyphIndex the index of the ReactionGlyph object to create an alias SpeciesGlyph for.
+/// @return integer value indicating success/failure of the function.
+LIBSBMLNETWORK_EXTERN int createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex);
+
 /// @brief Returns the Dimensions object of the Layout object with the given index in the ListOfLayouts of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @param layoutIndex the index number of the Layout to return.


### PR DESCRIPTION
- The function to create alias node for a specific species in a specific reaction is added to Python, C, and C++ layers
- Docs are updated accordingly