### PR TITLE
fix-bugs-and-add-new-features

### DIFF
--- a/src/autolayout/libsbmlnetwork_autolayout_node.cpp
+++ b/src/autolayout/libsbmlnetwork_autolayout_node.cpp
@@ -168,13 +168,17 @@ GraphicalObject* AutoLayoutCentroidNode::getGraphicalObject() {
 
 void AutoLayoutCentroidNode::updateDimensions() {
     std::string fixedWidth = LIBSBMLNETWORK_CPP_NAMESPACE::getUserData(getGraphicalObject(), "width");
-    if (fixedWidth.empty())
-        setWidth(std::max(calculateWidth(), getWidth()));
+    if (fixedWidth.empty()) {
+        if (!isSetCurve())
+            setWidth(std::max(calculateWidth(), getWidth()));
+    }
     else
         setWidth(std::stod(fixedWidth));
     std::string fixedHeight = LIBSBMLNETWORK_CPP_NAMESPACE::getUserData(getGraphicalObject(), "height");
-    if (fixedHeight.empty())
-        setHeight(std::max(calculateHeight(), getHeight()));
+    if (fixedHeight.empty()) {
+        if (!isSetCurve())
+            setHeight(std::max(calculateHeight(), getHeight()));
+    }
     else
         setHeight(std::stod(fixedHeight));
 }

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -1886,7 +1886,7 @@ class LibSBMLNetwork:
         lib.c_api_getX.restype = ctypes.c_double
         return lib.c_api_getX(self.sbml_object, str(id).encode(), graphical_object_index, layout_index)
 
-    def setX(self, id, x, graphical_object_index=0, layout_index=0):
+    def setX(self, id, x, graphical_object_index=0, layout_index=0, update_curves=True):
         """
         Sets the x-coordinate of the GraphicalObject associated with the given id, graphical_object_index, and layout_index in the given SBMLDocument
 
@@ -1896,12 +1896,13 @@ class LibSBMLNetwork:
             - x (float): a float that determines the x-coordinate of the GraphicalObject
             - graphical_object_index (int): an integer that determines the index of the GraphicalObject in the given SBMLDocument
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the x-coordinate of the GraphicalObject could not be set
         """
-        return lib.c_api_setX(self.sbml_object, str(id).encode(), ctypes.c_double(x), graphical_object_index, layout_index)
+        return lib.c_api_setX(self.sbml_object, str(id).encode(), ctypes.c_double(x), graphical_object_index, layout_index, update_curves)
 
     def getY(self, id, graphical_object_index=0, layout_index=0):
         """
@@ -1920,7 +1921,7 @@ class LibSBMLNetwork:
         lib.c_api_getY.restype = ctypes.c_double
         return lib.c_api_getY(self.sbml_object, str(id).encode(), graphical_object_index, layout_index)
 
-    def setY(self, id, y, graphical_object_index=0, layout_index=0):
+    def setY(self, id, y, graphical_object_index=0, layout_index=0, update_curves=True):
         """
         Sets the y-coordinate of the GraphicalObject associated with the given id, graphical_object_index, and layout_index in the given SBMLDocument
 
@@ -1930,12 +1931,13 @@ class LibSBMLNetwork:
             - y (float): a float that determines the y-coordinate of the GraphicalObject
             - graphical_object_index (int): an integer that determines the index of the GraphicalObject in the given SBMLDocument
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the y-coordinate of the GraphicalObject could not be set
         """
-        return lib.c_api_setY(self.sbml_object, str(id).encode(), ctypes.c_double(y), graphical_object_index, layout_index)
+        return lib.c_api_setY(self.sbml_object, str(id).encode(), ctypes.c_double(y), graphical_object_index, layout_index, update_curves)
 
     def getPosition(self, id, graphical_object_index=0, layout_index=0):
         """
@@ -1955,7 +1957,7 @@ class LibSBMLNetwork:
         lib.c_api_getY.restype = ctypes.c_double
         return (lib.c_api_getX(self.sbml_object, str(id).encode(), graphical_object_index, layout_index), lib.c_api_getY(self.sbml_object, str(id).encode(), graphical_object_index, layout_index))
 
-    def setPosition(self, id, x, y, graphical_object_index=0, layout_index=0):
+    def setPosition(self, id, x, y, graphical_object_index=0, layout_index=0, update_curves=True):
         """
         Sets the position of the GraphicalObject associated with the given id, graphical_object_index, and layout_index in the given SBMLDocument
 
@@ -1966,12 +1968,13 @@ class LibSBMLNetwork:
             - y (float): a float that determines the y-coordinate of the GraphicalObject
             - graphical_object_index (int): an integer that determines the index of the GraphicalObject in the given SBMLDocument
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the position of the GraphicalObject could not be set
         """
-        return lib.c_api_setPosition(self.sbml_object, str(id).encode(), ctypes.c_double(x), ctypes.c_double(y), graphical_object_index, layout_index)
+        return lib.c_api_setPosition(self.sbml_object, str(id).encode(), ctypes.c_double(x), ctypes.c_double(y), graphical_object_index, layout_index, update_curves)
 
     def getWidth(self, id, graphical_object_index=0, layout_index=0):
         """
@@ -1990,7 +1993,7 @@ class LibSBMLNetwork:
         lib.c_api_getWidth.restype = ctypes.c_double
         return lib.c_api_getWidth(self.sbml_object, str(id).encode(), graphical_object_index, layout_index)
 
-    def setWidth(self, id, width, graphical_object_index=0, layout_index=0):
+    def setWidth(self, id, width, graphical_object_index=0, layout_index=0, update_curves=True):
         """
         Sets the width of the GraphicalObject associated with the given id, graphical_object_index, and layout_index in the given SBMLDocument
 
@@ -2000,14 +2003,15 @@ class LibSBMLNetwork:
             - width (float): a float that determines the width of the GraphicalObject
             - graphical_object_index (int): an integer that determines the index of the GraphicalObject in the given SBMLDocument
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the width of the GraphicalObject could not be set
         """
-        return lib.c_api_setWidth(self.sbml_object, str(id).encode(), ctypes.c_double(width), graphical_object_index, layout_index)
+        return lib.c_api_setWidth(self.sbml_object, str(id).encode(), ctypes.c_double(width), graphical_object_index, layout_index, update_curves)
 
-    def setCompartmentsWidth(self, width, layout_index=0):
+    def setCompartmentsWidth(self, width, layout_index=0, update_curves=True):
         """
         Sets the width of all the Compartments in the Layout object with the given index in the given SBMLDocument
 
@@ -2015,12 +2019,13 @@ class LibSBMLNetwork:
 
             - width (float): a float that determines the width of the Compartments
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the width of the Compartments could not be set
         """
-        return lib.c_api_setCompartmentsWidth(self.sbml_object, ctypes.c_double(width), layout_index)
+        return lib.c_api_setCompartmentsWidth(self.sbml_object, ctypes.c_double(width), layout_index, update_curves)
 
     def getSpeciesWidth(self, layout_index=0):
         """
@@ -2037,7 +2042,7 @@ class LibSBMLNetwork:
         lib.c_api_getSpeciesWidth.restype = ctypes.c_double
         return lib.c_api_getSpeciesWidth(self.sbml_object, layout_index)
 
-    def setSpeciesWidth(self, width, layout_index=0):
+    def setSpeciesWidth(self, width, layout_index=0, update_curves=True):
         """
         Sets the width of all the Species in the Layout object with the given index in the given SBMLDocument
 
@@ -2045,12 +2050,13 @@ class LibSBMLNetwork:
 
             - width (float): a float that determines the width of the Species
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the width of the Species could not be set
         """
-        return lib.c_api_setSpeciesWidth(self.sbml_object, ctypes.c_double(width), layout_index)
+        return lib.c_api_setSpeciesWidth(self.sbml_object, ctypes.c_double(width), layout_index, update_curves)
 
     def getReactionsWidth(self, layout_index=0):
         """
@@ -2067,7 +2073,7 @@ class LibSBMLNetwork:
         lib.c_api_getReactionsWidth.restype = ctypes.c_double
         return lib.c_api_getReactionsWidth(self.sbml_object, layout_index)
 
-    def setReactionsWidth(self, width, layout_index=0):
+    def setReactionsWidth(self, width, layout_index=0, update_curves=True):
         """
         Sets the width of all the Reactions in the Layout object with the given index in the given SBMLDocument
 
@@ -2075,12 +2081,13 @@ class LibSBMLNetwork:
 
             - width (float): a float that determines the width of the Reactions
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the width of the Reactions could not be set
         """
-        return lib.c_api_setReactionsWidth(self.sbml_object, ctypes.c_double(width), layout_index)
+        return lib.c_api_setReactionsWidth(self.sbml_object, ctypes.c_double(width), layout_index, update_curves)
 
     def getHeight(self, id, graphical_object_index=0, layout_index=0):
         """
@@ -2099,7 +2106,7 @@ class LibSBMLNetwork:
         lib.c_api_getHeight.restype = ctypes.c_double
         return lib.c_api_getHeight(self.sbml_object, str(id).encode(), graphical_object_index, layout_index)
 
-    def setHeight(self, id, height, graphical_object_index=0, layout_index=0):
+    def setHeight(self, id, height, graphical_object_index=0, layout_index=0, update_curves=True):
         """
         Sets the height of the GraphicalObject associated with the given id, graphical_object_index, and layout_index in the given SBMLDocument
 
@@ -2109,14 +2116,15 @@ class LibSBMLNetwork:
             - height (float): a float that determines the height of the GraphicalObject
             - graphical_object_index (int): an integer that determines the index of the GraphicalObject in the given SBMLDocument
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the height of the GraphicalObject could not be set
         """
-        return lib.c_api_setHeight(self.sbml_object, str(id).encode(), ctypes.c_double(height), graphical_object_index, layout_index)
+        return lib.c_api_setHeight(self.sbml_object, str(id).encode(), ctypes.c_double(height), graphical_object_index, layout_index, update_curves)
 
-    def setCompartmentsHeight(self, height, layout_index=0):
+    def setCompartmentsHeight(self, height, layout_index=0, update_curves=True):
         """
         Sets the height of all the Compartments in the Layout object with the given index in the given SBMLDocument
 
@@ -2124,12 +2132,13 @@ class LibSBMLNetwork:
 
             - height (float): a float that determines the height of the Compartments
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the height of the Compartments could not be set
         """
-        return lib.c_api_setCompartmentsHeight(self.sbml_object, ctypes.c_double(height), layout_index)
+        return lib.c_api_setCompartmentsHeight(self.sbml_object, ctypes.c_double(height), layout_index, update_curves)
 
     def getSpeciesHeight(self, layout_index=0):
         """
@@ -2146,7 +2155,7 @@ class LibSBMLNetwork:
         lib.c_api_getSpeciesHeight.restype = ctypes.c_double
         return lib.c_api_getSpeciesHeight(self.sbml_object, layout_index)
 
-    def setSpeciesHeight(self, height, layout_index=0):
+    def setSpeciesHeight(self, height, layout_index=0, update_curves=True):
         """
         Sets the height of all the Species in the Layout object with the given index in the given SBMLDocument
 
@@ -2154,12 +2163,13 @@ class LibSBMLNetwork:
 
             - height (float): a float that determines the height of the Species
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the height of the Species could not be set
         """
-        return lib.c_api_setSpeciesHeight(self.sbml_object, ctypes.c_double(height), layout_index)
+        return lib.c_api_setSpeciesHeight(self.sbml_object, ctypes.c_double(height), layout_index, update_curves)
 
     def getReactionsHeight(self, layout_index=0):
         """
@@ -2176,7 +2186,7 @@ class LibSBMLNetwork:
         lib.c_api_getReactionsHeight.restype = ctypes.c_double
         return lib.c_api_getReactionsHeight(self.sbml_object, layout_index)
 
-    def setReactionsHeight(self, height, layout_index=0):
+    def setReactionsHeight(self, height, layout_index=0, update_curves=True):
         """
         Sets the height of all the Reactions in the Layout object with the given index in the given SBMLDocument
 
@@ -2184,12 +2194,13 @@ class LibSBMLNetwork:
 
             - height (float): a float that determines the height of the Reactions
             - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+            - update_curves (bool, optional): a boolean (default: True) that determines whether the curves should be updated
 
         :Returns:
 
             true on success and false if the height of the Reactions could not be set
         """
-        return lib.c_api_setReactionsHeight(self.sbml_object, ctypes.c_double(height), layout_index)
+        return lib.c_api_setReactionsHeight(self.sbml_object, ctypes.c_double(height), layout_index, update_curves)
 
     def getTextX(self, id, graphical_object_index=0, text_glyph_index=0, layout_index=0):
         """

--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -1039,6 +1039,41 @@ class LibSBMLNetwork:
         lib.c_api_getSpeciesReferenceSpeciesGlyphId.restype = ctypes.c_char_p
         return ctypes.c_char_p(lib.c_api_getSpeciesReferenceSpeciesGlyphId(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_index, layout_index)).value.decode()
 
+    def isSetSpeciesReferenceEmptySpeciesGlyph(self, reaction_id, reaction_glyph_index=0, species_reference_index=0, layout_index=0):
+        """
+        Returns whether the SpeciesReference with the given reaction_id, reaction_glyph_index, species_reference_index, and layout_index in the given SBMLDocument is associated with an empty SpeciesGlyph
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction
+            - reaction_glyph_index (int): an integer that determines the index of the ReactionGlyph in the given SBMLDocument
+            - species_reference_index (int): an integer that determines the index of the SpeciesReference in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            true if the SpeciesReference with the given reaction_id, reaction_glyph_index, species_reference_index, and layout_index in the given SBMLDocument is associated with an empty SpeciesGlyph and false otherwise
+        """
+        return lib.c_api_isSetSpeciesReferenceEmptySpeciesGlyph(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_index, layout_index)
+
+    def getSpeciesReferenceEmptySpeciesGlyphId(self, reaction_id, reaction_glyph_index=0, species_reference_index=0, layout_index=0):
+        """
+        Returns the id of the empty SpeciesGlyph associated with the SpeciesReference with the given reaction_id, reaction_glyph_index, species_reference_index, and layout_index in the given SBMLDocument
+
+        :Parameters:
+
+            - reaction_id (string): a string that determines the id of the Reaction
+            - reaction_glyph_index (int): an integer that determines the index of the ReactionGlyph in the given SBMLDocument
+            - species_reference_index (int): an integer that determines the index of the SpeciesReference in the given SBMLDocument
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a string that determines the id of the empty SpeciesGlyph associated with the SpeciesReference with the given reaction_id, reaction_glyph_index, species_reference_index, and layout_index in the given SBMLDocument
+        """
+        lib.c_api_getSpeciesReferenceEmptySpeciesGlyphId.restype = ctypes.c_char_p
+        return ctypes.c_char_p(lib.c_api_getSpeciesReferenceEmptySpeciesGlyphId(self.sbml_object, str(reaction_id).encode(), reaction_glyph_index, species_reference_index, layout_index)).value.decode()
+
     def isSetSpeciesReferenceRole(self, reaction_id, reaction_glyph_index=0, species_reference_index=0, layout_index=0):
         """
         Returns whether the role of the SpeciesReference with the given reaction_id, reaction_glyph_index, species_reference_index, and layout_index in the given SBMLDocument is set

--- a/src/bindings/python/ctypes/sbmlnetwork/src/sbmlnetwork/sbmlnetwork.py
+++ b/src/bindings/python/ctypes/sbmlnetwork/src/sbmlnetwork/sbmlnetwork.py
@@ -16,12 +16,12 @@ class SBMLNetwork(libsbmlnetwork.LibSBMLNetwork):
         :param file_name:
         """
         if file_name:
-            networkinfotranslator.import_sbml_export_figure(self.save(), file_name, self.use_name_as_text_label,
+            networkinfotranslator.import_sbml_export_figure(self, file_name, self.use_name_as_text_label,
                                                             self.display_compartments_text_label,
                                                             self.display_species_text_label,
                                                             self.display_reactions_text_label)
         else:
-            display(networkinfotranslator.import_sbml_export_pil_image(self.save(), self.use_name_as_text_label,
+            display(networkinfotranslator.import_sbml_export_pil_image(self, self.use_name_as_text_label,
                                                                        self.display_compartments_text_label,
                                                                        self.display_species_text_label,
                                                                        self.display_reactions_text_label))

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -353,6 +353,14 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return strdup(getSpeciesReferenceSpeciesGlyphId(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex).c_str());
     }
 
+    bool c_api_isSetSpeciesReferenceEmptySpeciesGlyph(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceIndex, int layoutIndex) {
+        return isSetSpeciesReferenceEmptySpeciesGlyph(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex);
+    }
+
+    const char* c_api_getSpeciesReferenceEmptySpeciesGlyphId(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceIndex, int layoutIndex) {
+        return strdup(getSpeciesReferenceEmptySpeciesGlyphId(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex).c_str());
+    }
+
     bool c_api_isSetSpeciesReferenceRole(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceIndex, int layoutIndex) {
         return isSetSpeciesReferenceRole(document, layoutIndex, reactionId, reactionGlyphIndex, speciesReferenceIndex);
     }

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -541,76 +541,76 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return getPositionX(document, layoutIndex, id, graphicalObjectIndex);
     }
 
-    int c_api_setX(SBMLDocument* document, const char* id, const double x, const int graphicalObjectIndex, int layoutIndex) {
-        return setPositionX(document, layoutIndex, id, graphicalObjectIndex, x);
+    int c_api_setX(SBMLDocument* document, const char* id, const double x, const int graphicalObjectIndex, int layoutIndex, bool updateCurves) {
+        return setPositionX(document, layoutIndex, id, graphicalObjectIndex, x, updateCurves);
     }
 
     const double c_api_getY(SBMLDocument* document, const char* id, const int graphicalObjectIndex, int layoutIndex) {
         return getPositionY(document, layoutIndex, id, graphicalObjectIndex);
     }
 
-    int c_api_setY(SBMLDocument* document, const char* id, const double y, const int graphicalObjectIndex, int layoutIndex) {
-        return setPositionY(document, layoutIndex, id, graphicalObjectIndex, y);
+    int c_api_setY(SBMLDocument* document, const char* id, const double y, const int graphicalObjectIndex, int layoutIndex, bool updateCurves) {
+        return setPositionY(document, layoutIndex, id, graphicalObjectIndex, y, updateCurves);
     }
 
-    int c_api_setPosition(SBMLDocument* document, const char* id, const double x, const double y, const int graphicalObjectIndex, int layoutIndex) {
-        return setPosition(document, layoutIndex, id, graphicalObjectIndex, x, y);
+    int c_api_setPosition(SBMLDocument* document, const char* id, const double x, const double y, const int graphicalObjectIndex, int layoutIndex, bool updateCurves) {
+        return setPosition(document, layoutIndex, id, graphicalObjectIndex, x, y, updateCurves);
     }
 
     const double c_api_getWidth(SBMLDocument* document, const char* id, const int graphicalObjectIndex, int layoutIndex) {
         return getDimensionWidth(document, layoutIndex, id, graphicalObjectIndex);
     }
 
-    int c_api_setWidth(SBMLDocument* document, const char* id, const double width, const int graphicalObjectIndex, int layoutIndex) {
-        return setDimensionWidth(document, layoutIndex, id, graphicalObjectIndex, width);
+    int c_api_setWidth(SBMLDocument* document, const char* id, const double width, const int graphicalObjectIndex, int layoutIndex, bool updateCurves) {
+        return setDimensionWidth(document, layoutIndex, id, graphicalObjectIndex, width, updateCurves);
     }
 
-    int c_api_setCompartmentsWidth(SBMLDocument* document, const double width, int layoutIndex) {
-        return setCompartmentDimensionWidth(document, layoutIndex, width);
+    int c_api_setCompartmentsWidth(SBMLDocument* document, const double width, int layoutIndex, bool updateCurves) {
+        return setCompartmentDimensionWidth(document, layoutIndex, width, updateCurves);
     }
 
     const double c_api_getSpeciesWidth() {
         return getSpeciesDimensionWidth();
     }
 
-    int c_api_setSpeciesWidth(SBMLDocument* document, const double width, int layoutIndex) {
-        return setSpeciesDimensionWidth(document, layoutIndex, width);
+    int c_api_setSpeciesWidth(SBMLDocument* document, const double width, int layoutIndex, bool updateCurves) {
+        return setSpeciesDimensionWidth(document, layoutIndex, width, updateCurves);
     }
 
     const double c_api_getReactionsWidth() {
         return getReactionDimensionWidth();
     }
 
-    int c_api_setReactionsWidth(SBMLDocument* document, const double width, int layoutIndex) {
-        return setReactionDimensionWidth(document, layoutIndex, width);
+    int c_api_setReactionsWidth(SBMLDocument* document, const double width, int layoutIndex, bool updateCurves) {
+        return setReactionDimensionWidth(document, layoutIndex, width, updateCurves);
     }
 
     const double c_api_getHeight(SBMLDocument* document, const char* id, const int graphicalObjectIndex, int layoutIndex) {
         return getDimensionHeight(document, layoutIndex, id, graphicalObjectIndex);
     }
 
-    int c_api_setHeight(SBMLDocument* document, const char* id, const double height, const int graphicalObjectIndex, int layoutIndex) {
-        return setDimensionHeight(document, layoutIndex, id, graphicalObjectIndex, height);
+    int c_api_setHeight(SBMLDocument* document, const char* id, const double height, const int graphicalObjectIndex, int layoutIndex, bool updateCurves) {
+        return setDimensionHeight(document, layoutIndex, id, graphicalObjectIndex, height, updateCurves);
     }
 
-    int c_api_setCompartmentsHeight(SBMLDocument* document, const double height, int layoutIndex) {
-        return setCompartmentDimensionHeight(document, layoutIndex, height);
+    int c_api_setCompartmentsHeight(SBMLDocument* document, const double height, int layoutIndex, bool updateCurves) {
+        return setCompartmentDimensionHeight(document, layoutIndex, height, updateCurves);
     }
 
     const double c_api_getSpeciesHeight() {
         return getSpeciesDimensionHeight();
     }
 
-    int c_api_setSpeciesHeight(SBMLDocument* document, const double height, int layoutIndex) {
-        return setSpeciesDimensionHeight(document, layoutIndex, height);
+    int c_api_setSpeciesHeight(SBMLDocument* document, const double height, int layoutIndex, bool updateCurves) {
+        return setSpeciesDimensionHeight(document, layoutIndex, height, updateCurves);
     }
 
     const double c_api_getReactionsHeight() {
         return getReactionDimensionHeight();
     }
 
-    int c_api_setReactionsHeight(SBMLDocument* document, const double height, int layoutIndex) {
-        return setReactionDimensionHeight(document, layoutIndex, height);
+    int c_api_setReactionsHeight(SBMLDocument* document, const double height, int layoutIndex, bool updateCurves) {
+        return setReactionDimensionHeight(document, layoutIndex, height, updateCurves);
     }
 
     const double c_api_getTextX(SBMLDocument* document, const char* id, const int graphicalObjectIndex, const int textGlyphIndex, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -982,8 +982,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
     /// @param x a double value to be set as "x" attribute of the bounding box of the GraphicalObject object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setX(SBMLDocument* document, const char* id, const double x, const int graphicalObjectIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setX(SBMLDocument* document, const char* id, const double x, const int graphicalObjectIndex = 0, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the value of the "y" attribute of the bounding box of the GraphicalObject with the given index associated with
     /// the model entity with the given id of the Layout object with the given index in the SBML document.
@@ -999,8 +1000,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
     /// @param y a double value to be set as "y" attribute of the bounding box of the GraphicalObject object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setY(SBMLDocument* document, const char* id, const double y, const int graphicalObjectIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setY(SBMLDocument* document, const char* id, const double y, const int graphicalObjectIndex = 0, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Sets the values of the "x" and "y" attributes of the bounding box of the GraphicalObject with the given index associated with
     /// the model entity with the given id of the Layout object with the given index in the SBML document.
@@ -1009,8 +1011,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param x a double value to be set as "x" attribute of the bounding box of the GraphicalObject object.
     /// @param y a double value to be set as "y" attribute of the bounding box of the GraphicalObject object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setPosition(SBMLDocument* document, const char* id, const double x, const double y, const int graphicalObjectIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setPosition(SBMLDocument* document, const char* id, const double x, const double y, const int graphicalObjectIndex = 0, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the value of the "width" attribute of the bounding box of the GraphicalObject with the given index associated with
     /// the model entity with the given id of the Layout object with the given index in the SBML document.
@@ -1026,15 +1029,17 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
     /// @param width a double value to be set as "width" attribute of the bounding box of the GraphicalObject object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setWidth(SBMLDocument* document, const char* id, const double width, const int graphicalObjectIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setWidth(SBMLDocument* document, const char* id, const double width, const int graphicalObjectIndex = 0, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Sets the values of the "width" attribute of the bounding box of all the Compartments of the Layout object with the given index in the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param width a double value to be set as "width" attribute of the bounding box of the Compartments object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsWidth(SBMLDocument* document, const double width, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsWidth(SBMLDocument* document, const double width, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the default value of the "width" attribute of the bounding box of the SpeciesGlyph objects.
     /// @return the default value of the "width" attribute of the bounding box of the SpeciesGlyph objects.
@@ -1044,8 +1049,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param document a pointer to the SBMLDocument object.
     /// @param width a double value to be set as "width" attribute of the bounding box of the Species object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesWidth(SBMLDocument* document, const double width, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesWidth(SBMLDocument* document, const double width, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the default value of the "width" attribute of the bounding box of the ReactionGlyph objects.
     /// @return the default value of the "width" attribute of the bounding box of the ReactionGlyph objects.
@@ -1055,8 +1061,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param document a pointer to the SBMLDocument object.
     /// @param width a double value to be set as "width" attribute of the bounding box of the Reactions object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionsWidth(SBMLDocument* document, const double width, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionsWidth(SBMLDocument* document, const double width, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the value of the "height" attribute of the bounding box of the GraphicalObject with the given index associated with
     /// the model entity with the given id of the Layout object with the given index in the SBML document.
@@ -1072,15 +1079,17 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
     /// @param height a double value to be set as "height" attribute of the bounding box of the GraphicalObject object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setHeight(SBMLDocument* document, const char* id, const double height, const int graphicalObjectIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setHeight(SBMLDocument* document, const char* id, const double height, const int graphicalObjectIndex = 0, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Sets the values of the "height" attribute of the bounding box of all the Compartments of the Layout object with the given index in the SBML document.
     /// @param document a pointer to the SBMLDocument object.
     /// @param height a double value to be set as "height" attribute of the bounding box of the Compartments object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsHeight(SBMLDocument* document, const double height, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setCompartmentsHeight(SBMLDocument* document, const double height, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the default value of the "height" attribute of the bounding box of the SpeciesGlyph objects.
     /// @return the default value of the "height" attribute of the bounding box of the SpeciesGlyph objects.
@@ -1090,8 +1099,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param document a pointer to the SBMLDocument object.
     /// @param height a double value to be set as "height" attribute of the bounding box of the Species object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesHeight(SBMLDocument* document, const double height, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setSpeciesHeight(SBMLDocument* document, const double height, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the default value of the "height" attribute of the bounding box of the ReactionGlyph objects.
     /// @return the default value of the "height" attribute of the bounding box of the ReactionGlyph objects.
@@ -1101,8 +1111,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param document a pointer to the SBMLDocument object.
     /// @param height a double value to be set as "height" attribute of the bounding box of the Reactions object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves a boolean value to indicate whether the function should update the curves after setting the value.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_setReactionsHeight(SBMLDocument* document, const double height, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN int c_api_setReactionsHeight(SBMLDocument* document, const double height, int layoutIndex = 0, bool updateCurves = true);
 
     /// @brief Returns the value of the "x" attribute of the bounding box of the TextGlyph object with the given index associated with
     /// the model entity with the given id of the Layout object with the given index in the SBML document.

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -481,6 +481,25 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// the SpeciesReference does not exits or the object is @c NULL
     LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceSpeciesGlyphId(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex = 0, int speciesReferenceIndex = 0, int layoutIndex = 0);
 
+    /// @brief Predicate returning true if the SpeciesGlyph associated with the SpeciesReferenceGlyph with the given index in the given ReactionGlyph object with the given index associated with the entered reaction id is an empty SpeciesGlyph.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction the number of SpeciesReference objects of its ReactionGlyph object with the given index associated with it is going to be returned.
+    /// @param reactionGlyphIndex the index of the ReactionGlyph.
+    /// @param speciesReferenceIndex the index of the SpeciesReference.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return @c true if the SpeciesGlyph associated with the SpeciesReferenceGlyph with the given index is an empty SpeciesGlyph, @c false otherwise.
+    LIBSBMLNETWORK_EXTERN bool c_api_isSetSpeciesReferenceEmptySpeciesGlyph(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceIndex, int layoutIndex);
+
+    /// @brief Returns the id of the empty species glyph associated with the SpeciesReference object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
+    /// of the the Layout object with the given index in the ListOfLayouts of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param reactionId the id of the reaction the number of SpeciesReference objects of its ReactionGlyph object with the given index associated with it is going to be returned.
+    /// @param reactionGlyphIndex the index of the ReactionGlyph.
+    /// @param speciesReferenceIndex the index of the SpeciesReference.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return the id of the empty SpeciesGlyph associated with the SpeciesReference object with the given index, or @c "" if the SpeciesGlyph is not empty or the object is @c NULL
+    LIBSBMLNETWORK_EXTERN const char* c_api_getSpeciesReferenceEmptySpeciesGlyphId(SBMLDocument* document, const char* reactionId, int reactionGlyphIndex, int speciesReferenceIndex, int layoutIndex);
+
     /// @brief Predicates returning @c true if the "role" attribute of the SpeciesReference object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
     /// of the Layout object with the given index in the ListOfLayouts of the SBML document is set.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_layout.cpp
+++ b/src/libsbmlnetwork_layout.cpp
@@ -99,6 +99,8 @@ GraphicalObject* getGraphicalObject(Layout* layout, const std::string& id, const
     std::vector<GraphicalObject*> graphicalObjects = getGraphicalObjects(layout, id);
     if (graphicalObjectIndex < graphicalObjects.size())
         return graphicalObjects.at(graphicalObjectIndex);
+    else if (graphicalObjectIndex == 0)
+        return getGraphicalObjectUsingItsOwnId(layout, id);
 
     return NULL;
 }
@@ -221,6 +223,17 @@ bool isSpeciesGlyph(Layout* layout, const std::string& id, const unsigned int sp
 
 bool isSpeciesGlyph(GraphicalObject* graphicalObject) {
     if (dynamic_cast<SpeciesGlyph*>(graphicalObject))
+        return true;
+
+    return false;
+}
+
+bool isEmptySpeciesGlyph(Layout* layout, const std::string& id, const unsigned int speciesGlyphIndex) {
+    return isEmptySpeciesGlyph(getGraphicalObject(layout, id, speciesGlyphIndex));
+}
+
+bool isEmptySpeciesGlyph(GraphicalObject* graphicalObject) {
+    if (isSpeciesGlyph(graphicalObject) && !((SpeciesGlyph*)graphicalObject)->isSetSpeciesId())
         return true;
 
     return false;
@@ -360,6 +373,14 @@ const std::string getSpeciesReferenceSpeciesGlyphId(GraphicalObject* speciesRefe
         return ((SpeciesReferenceGlyph*)speciesReferenceGlyph)->getSpeciesGlyphId();
 
     return "";
+}
+
+bool isSetEmptySpeciesGlyph(Layout* layout, const std::string& id, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetEmptySpeciesGlyph(layout, getSpeciesReference(layout, id, reactionGlyphIndex, speciesReferenceIndex));
+}
+
+const std::string getEmptySpeciesGlyphId(Layout* layout, const std::string& id, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getEmptySpeciesGlyphId(layout, getSpeciesReference(layout, id, reactionGlyphIndex, speciesReferenceIndex));
 }
 
 bool isSetRole(Layout* layout, const std::string& id, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {

--- a/src/libsbmlnetwork_layout.h
+++ b/src/libsbmlnetwork_layout.h
@@ -196,6 +196,18 @@ LIBSBMLNETWORK_EXTERN bool isSpeciesGlyph(Layout* layout, const std::string& id,
 /// @return @c true if this abstract GraphicalObject is of type SpeciesGlyph, false otherwise
 LIBSBMLNETWORK_EXTERN bool isSpeciesGlyph(GraphicalObject* graphicalObject);
 
+/// @brief Predicate returning true if the SpeciesGlyph object with the given id of the Layout object is an empty SpeciesGlyph.
+/// @param Layout a pointer to the Layout object.
+/// @param id the id of the species the the SpeciesGlyph objects of which to be returned.
+/// @param speciesGlyphIndex the index of the SpeciesGlyph to return.
+/// @return @c true if this SpeciesGlyph object is an empty SpeciesGlyph, false otherwise
+LIBSBMLNETWORK_EXTERN bool isEmptySpeciesGlyph(Layout* layout, const std::string& id, const unsigned int speciesGlyphIndex = 0);
+
+/// @brief Predicate returning true if this SpeciesGlyph object is an empty SpeciesGlyph.
+/// @param graphicalObject a pointer to the GraphicalObject object.
+/// @return @c true if this SpeciesGlyph object is an empty SpeciesGlyph, false otherwise
+LIBSBMLNETWORK_EXTERN bool isEmptySpeciesGlyph(GraphicalObject* graphicalObject);
+
 /// @brief Returns the ids of the ReactionGlyph objects of the Layout object
 /// @param layout a pointer to the Layout object
 /// @return the ids of the ReactionGlyph objects of the Layout object
@@ -337,6 +349,10 @@ LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceSpeciesGlyphId(Graphi
 /// @param speciesReference a pointer to the GraphicalObject object.
 /// @return the value of the "speciesGlyph" attribute, or @c "" if the object is not of type SpeciesReferenceGlyph object or is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceSpeciesGlyphId(GraphicalObject* speciesReferenceGlyph);
+
+bool isSetEmptySpeciesGlyph(Layout* layout, const std::string& id, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+const std::string getEmptySpeciesGlyphId(Layout* layout, const std::string& id, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
 
 /// @brief Predicates returning @c true if the "role" attribute of the SpeciesReference object with the given index of the ReactionGlyph object with the given id of the Layout object is set.
 /// @param Layout a pointer to the Layout object.

--- a/src/libsbmlnetwork_layout_helpers.cpp
+++ b/src/libsbmlnetwork_layout_helpers.cpp
@@ -299,7 +299,7 @@ const double getSpeciesDefaultHeight() {
     return 36.0;
 }
 
-const double getDummySpeciesDefaultRadius() {
+const double getEmptySpeciesDefaultRadius() {
     return 15.0;
 }
 
@@ -493,7 +493,7 @@ void setReactionGlyphs(Model* model, Layout* layout, const int maxNumConnectedEd
         setReactantGlyphs(layout, reaction, reactionGlyph, maxNumConnectedEdges, userData);
         setProductGlyphs(layout, reaction, reactionGlyph, maxNumConnectedEdges, userData);
         setModifierGlyphs(layout, reaction, reactionGlyph, maxNumConnectedEdges, userData);
-        setDummySpeciesReferenceGlyphs(model, layout, reactionGlyph, userData);
+        setEmptySpeciesReferenceGlyphs(model, layout, reactionGlyph, userData);
     }
 }
 
@@ -536,44 +536,60 @@ void setModifierGlyphs(Layout* layout, Reaction* reaction, ReactionGlyph* reacti
     }
 }
 
-void setDummySpeciesReferenceGlyphs(Model* model, Layout* layout, ReactionGlyph* reactionGlyph, const std::vector<std::map<std::string, std::string>>& userData) {
+void setEmptySpeciesReferenceGlyphs(Model* model, Layout* layout, ReactionGlyph* reactionGlyph, const std::vector<std::map<std::string, std::string>>& userData) {
     Reaction* reaction = findReactionGlyphReaction(model, reactionGlyph);
     if (reaction->getNumReactants() == 0) {
-        SpeciesReferenceGlyph* dummyReactantGlyph = createDummySpeciesReferenceGlyph(model, layout, reactionGlyph);
-        dummyReactantGlyph->setRole(SPECIES_ROLE_SUBSTRATE);
-        setGraphicalObjectUserData(dummyReactantGlyph, userData);
+        SpeciesReferenceGlyph* emptyReactantGlyph = createEmptySpeciesReferenceGlyph(model, layout, reactionGlyph);
+        emptyReactantGlyph->setRole(SPECIES_ROLE_SUBSTRATE);
+        setGraphicalObjectUserData(emptyReactantGlyph, userData);
     }
     else if (reaction->getNumProducts() == 0) {
-        SpeciesReferenceGlyph* dummyProductGlyph = createDummySpeciesReferenceGlyph(model, layout, reactionGlyph);
-        dummyProductGlyph->setRole(SPECIES_ROLE_PRODUCT);
-        setGraphicalObjectUserData(dummyProductGlyph, userData);
+        SpeciesReferenceGlyph* emptyProductGlyph = createEmptySpeciesReferenceGlyph(model, layout, reactionGlyph);
+        emptyProductGlyph->setRole(SPECIES_ROLE_PRODUCT);
+        setGraphicalObjectUserData(emptyProductGlyph, userData);
     }
 }
 
-SpeciesReferenceGlyph* createDummySpeciesReferenceGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph) {
-    SpeciesGlyph* dummySpeciesGlyph = createDummySpeciesGlyph(model, layout, reactionGlyph);
-    return createDummySpeciesReferenceGlyph(layout, reactionGlyph, dummySpeciesGlyph);
+SpeciesReferenceGlyph* createEmptySpeciesReferenceGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph) {
+    SpeciesGlyph* emptySpeciesGlyph = createEmptySpeciesGlyph(model, layout, reactionGlyph);
+    return createEmptySpeciesReferenceGlyph(layout, reactionGlyph, emptySpeciesGlyph);
 }
 
-SpeciesGlyph* createDummySpeciesGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph) {
-    SpeciesGlyph* dummySpeciesGlyph = createDummySpeciesGlyph(layout, reactionGlyph->getId());
+SpeciesGlyph* createEmptySpeciesGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph) {
+    SpeciesGlyph* emptySpeciesGlyph = createEmptySpeciesGlyph(layout, reactionGlyph->getId());
     CompartmentGlyph* compartmentGlyph = getCompartmentGlyphOfReactionGlyph(model, layout, reactionGlyph);
     if (compartmentGlyph)
-        setUserData(dummySpeciesGlyph, "compartment", compartmentGlyph->getCompartmentId());
-    setUserData(dummySpeciesGlyph, "width", std::to_string(2* getDummySpeciesDefaultRadius()));
-    setUserData(dummySpeciesGlyph, "height", std::to_string(2* getDummySpeciesDefaultRadius()));
-    setGraphicalObjectBoundingBox(dummySpeciesGlyph);
+        setUserData(emptySpeciesGlyph, "compartment", compartmentGlyph->getCompartmentId());
+    setUserData(emptySpeciesGlyph, "width", std::to_string(2* getEmptySpeciesDefaultRadius()));
+    setUserData(emptySpeciesGlyph, "height", std::to_string(2* getEmptySpeciesDefaultRadius()));
+    setGraphicalObjectBoundingBox(emptySpeciesGlyph);
 
-    return dummySpeciesGlyph;
+    return emptySpeciesGlyph;
 }
 
-SpeciesReferenceGlyph* createDummySpeciesReferenceGlyph(Layout* layout, ReactionGlyph* reactionGlyph, SpeciesGlyph* dummySpeciesGlyph) {
-    SpeciesReferenceGlyph* dummySpeciesReferenceGlyph = layout->createSpeciesReferenceGlyph();
-    dummySpeciesReferenceGlyph->setId(reactionGlyph->getId() + "_DummySpeciesReferenceGlyph");
-    dummySpeciesReferenceGlyph->setSpeciesGlyphId(dummySpeciesGlyph->getId());
-    setSpeciesReferenceGlyphCurve(dummySpeciesReferenceGlyph);
+SpeciesReferenceGlyph* createEmptySpeciesReferenceGlyph(Layout* layout, ReactionGlyph* reactionGlyph, SpeciesGlyph* emptySpeciesGlyph) {
+    SpeciesReferenceGlyph* emptySpeciesReferenceGlyph = layout->createSpeciesReferenceGlyph();
+    emptySpeciesReferenceGlyph->setId(reactionGlyph->getId() + "_EmptySpeciesReferenceGlyph");
+    emptySpeciesReferenceGlyph->setSpeciesGlyphId(emptySpeciesGlyph->getId());
+    setSpeciesReferenceGlyphCurve(emptySpeciesReferenceGlyph);
 
-    return dummySpeciesReferenceGlyph;
+    return emptySpeciesReferenceGlyph;
+}
+
+bool isSetEmptySpeciesGlyph(Layout* layout, SpeciesReferenceGlyph* speciesReferenceGlyph) {
+    if (layout && speciesReferenceGlyph) {
+        SpeciesGlyph* speciesGlyph = layout->getSpeciesGlyph(speciesReferenceGlyph->getSpeciesGlyphId());
+        return isEmptySpeciesGlyph(speciesGlyph);
+    }
+
+    return false;
+}
+
+const std::string getEmptySpeciesGlyphId(Layout* layout, SpeciesReferenceGlyph* speciesReferenceGlyph) {
+    if (isSetEmptySpeciesGlyph(layout, speciesReferenceGlyph))
+        return layout->getSpeciesGlyph(speciesReferenceGlyph->getSpeciesGlyphId())->getId();
+
+    return "";
 }
 
 int createAliasSpeciesGlyph(Layout* layout, const std::string speciesId, ReactionGlyph* reactionGlyph) {
@@ -887,9 +903,9 @@ SpeciesGlyph* createSpeciesGlyph(Layout* layout, const std::string& speciesId, c
     return speciesGlyph;
 }
 
-SpeciesGlyph* createDummySpeciesGlyph(Layout* layout, const std::string& reactionGlyphId) {
+SpeciesGlyph* createEmptySpeciesGlyph(Layout* layout, const std::string& reactionGlyphId) {
     SpeciesGlyph *speciesGlyph = layout->createSpeciesGlyph();
-    speciesGlyph->setId(reactionGlyphId + "_DummySpeciesGlyph");
+    speciesGlyph->setId(reactionGlyphId + "_EmptySpeciesGlyph");
     setGraphicalObjectBoundingBox(speciesGlyph);
 
     return speciesGlyph;

--- a/src/libsbmlnetwork_layout_helpers.h
+++ b/src/libsbmlnetwork_layout_helpers.h
@@ -66,7 +66,7 @@ const double getSpeciesDefaultWidth();
 
 const double getSpeciesDefaultHeight();
 
-const double getDummySpeciesDefaultRadius();
+const double getEmptySpeciesDefaultRadius();
 
 const double getReactionDefaultWidth();
 
@@ -114,17 +114,21 @@ void setProductGlyphs(Layout* layout, Reaction* reaction, ReactionGlyph* reactio
 
 void setModifierGlyphs(Layout* layout, Reaction* reaction, ReactionGlyph* reactionGlyph, const int maxNumConnectedEdges, const std::vector<std::map<std::string, std::string>>& userData);
 
-void setDummySpeciesReferenceGlyphs(Model* model, Layout* layout, ReactionGlyph* reactionGlyph, const std::vector<std::map<std::string, std::string>>& userData = {});
+void setEmptySpeciesReferenceGlyphs(Model* model, Layout* layout, ReactionGlyph* reactionGlyph, const std::vector<std::map<std::string, std::string>>& userData = {});
 
-SpeciesReferenceGlyph* createDummySpeciesReferenceGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph);
+SpeciesReferenceGlyph* createEmptySpeciesReferenceGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph);
 
-SpeciesGlyph* createDummySpeciesGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph);
+SpeciesGlyph* createEmptySpeciesGlyph(Model* model, Layout* layout, ReactionGlyph* reactionGlyph);
 
-SpeciesGlyph* createDummySpeciesGlyph(ReactionGlyph* reactionGlyph);
+SpeciesGlyph* createEmptySpeciesGlyph(ReactionGlyph* reactionGlyph);
 
-SpeciesReferenceGlyph* createDummySpeciesReferenceGlyph(Layout* layout, ReactionGlyph* reactionGlyph, SpeciesGlyph* dummySpeciesGlyph);
+SpeciesReferenceGlyph* createEmptySpeciesReferenceGlyph(Layout* layout, ReactionGlyph* reactionGlyph, SpeciesGlyph* EmptySpeciesGlyph);
 
 void setAliasSpeciesGlyphs(Layout* layout, const int maxNumConnectedEdges, const std::vector<std::map<std::string, std::string>>& userData = {});
+
+bool isSetEmptySpeciesGlyph(Layout* layout, SpeciesReferenceGlyph* speciesReferenceGlyph);
+
+const std::string getEmptySpeciesGlyphId(Layout* layout, SpeciesReferenceGlyph* speciesReferenceGlyph);
 
 int createAliasSpeciesGlyph(Layout* layout, const std::string speciesId, ReactionGlyph* reactionGlyph);
 
@@ -184,7 +188,7 @@ CompartmentGlyph* createCompartmentGlyph(Layout* layout, const std::string& comp
 
 SpeciesGlyph* createSpeciesGlyph(Layout* layout, const std::string& speciesId, const std::vector<std::map<std::string, std::string>>& userData = {});
 
-SpeciesGlyph* createDummySpeciesGlyph(Layout* layout, const std::string& reactionGlyphId);
+SpeciesGlyph* createEmptySpeciesGlyph(Layout* layout, const std::string& reactionGlyphId);
 
 ReactionGlyph* createReactionGlyph(Layout* layout, const std::string& reactionId, const std::vector<std::map<std::string, std::string>>& userData = {});
 

--- a/src/libsbmlnetwork_render_helpers.cpp
+++ b/src/libsbmlnetwork_render_helpers.cpp
@@ -143,6 +143,8 @@ const std::string getStyleType(GraphicalObject* graphicalObject) {
     if (graphicalObject) {
         if (isCompartmentGlyph(graphicalObject))
             return getCompartmentGlyphStyleType();
+        else if (isEmptySpeciesGlyph(graphicalObject))
+            return getEmptySpeciesGlyphStyleType();
         else if (isSpeciesGlyph(graphicalObject))
             return getSpeciesGlyphStyleType();
         else if (isReactionGlyph(graphicalObject))
@@ -175,6 +177,10 @@ const std::string getCompartmentGlyphStyleType() {
 
 const std::string getSpeciesGlyphStyleType() {
     return "SPECIESGLYPH";
+}
+
+const std::string getEmptySpeciesGlyphStyleType() {
+    return "EMPTY_SPECIESGLYPH";
 }
 
 const std::string getReactionGlyphStyleType() {
@@ -619,6 +625,7 @@ void addGlobalStyles(GlobalRenderInformation* globalRenderInformation) {
     addSpeciesGlyphGlobalStyle(globalRenderInformation);
     addReactionGlyphGlobalStyle(globalRenderInformation);
     addSpeciesReferenceGlyphGlobalStyles(globalRenderInformation);
+    addEmptySpeciesGlyphGlobalStyle(globalRenderInformation);
     addTextGlyphsGlobalStyles(globalRenderInformation);
 }
 
@@ -651,6 +658,14 @@ void addSpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation
         RenderGroup* renderGroup = globalStyle->createGroup();
         setSpeciesGlyphRenderGroupFeatures(renderGroup);
         setSpeciesGlyphTextGlyphRenderGroupFeatures(renderGroup);
+    }
+}
+
+void addEmptySpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation) {
+    if (!findStyleByTypeList(globalRenderInformation, getEmptySpeciesGlyphStyleType())) {
+        GlobalStyle* globalStyle = createGlobalStyleByType(globalRenderInformation, getEmptySpeciesGlyphStyleType());
+        RenderGroup* renderGroup = globalStyle->createGroup();
+        setEmptySpeciesGlyphRenderGroupFeatures(renderGroup);
     }
 }
 
@@ -836,6 +851,16 @@ void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
     rectangle->setRY(RelAbsVector(std::stod(getDefaultPredefinedStyleFeatures()["species-border-radius-y"]), 0.0));
 }
 
+void setEmptySpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
+    Ellipse* ellipse = renderGroup->createEllipse();
+    setDefaultEllipseShapeFeatures(ellipse);
+    ellipse->setFill(getDefaultPredefinedStyleFeatures()["species-fill-color"]);
+    ellipse->setStroke(getDefaultPredefinedStyleFeatures()["species-border-color"]);
+    RenderCurve* curve = renderGroup->createCurve();
+    setDefaultDiagonalRenderCurveFeatures(curve);
+    curve->setStroke(getDefaultPredefinedStyleFeatures()["species-border-color"]);
+    curve->setStrokeWidth(std::stod(getDefaultPredefinedStyleFeatures()["species-border-width"]));
+}
 
 void setSpeciesGlyphTextGlyphRenderGroupFeatures(RenderGroup* renderGroup) {
     setGeneralTextGlyphRenderGroupFeatures(renderGroup);
@@ -1047,6 +1072,17 @@ void setDefaultImageShapeFeatures(Image* image) {
     image->setY(RelAbsVector(0.0, 0.0));
     image->setWidth(RelAbsVector(0.0, 100.0));
     image->setHeight(RelAbsVector(0.0, 100.0));
+}
+
+void setDefaultDiagonalRenderCurveFeatures(RenderCurve* renderCurve) {
+    setDefault1DShapeFeatures(renderCurve);
+    RenderPoint* point = NULL;
+    point = renderCurve->createPoint();
+    point->setX(RelAbsVector(0.0, 100.0));
+    point->setY(RelAbsVector(0.0, 0.0));
+    point = renderCurve->createPoint();
+    point->setX(RelAbsVector(0.0, 0.0));
+    point->setY(RelAbsVector(0.0, 100.0));
 }
 
 void unifyGeometricShapeMutualFeatures(RenderGroup* renderGroup) {

--- a/src/libsbmlnetwork_render_helpers.h
+++ b/src/libsbmlnetwork_render_helpers.h
@@ -49,6 +49,8 @@ const std::string getCompartmentGlyphStyleType();
 
 const std::string getSpeciesGlyphStyleType();
 
+const std::string getEmptySpeciesGlyphStyleType();
+
 const std::string getReactionGlyphStyleType();
 
 const std::string getSpeciesReferenceGlyphStyleType();
@@ -157,6 +159,8 @@ void addCompartmentGlyphGlobalStyle(GlobalRenderInformation* globalRenderInforma
 
 void addSpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
 
+void addEmptySpeciesGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
+
 void addReactionGlyphGlobalStyle(GlobalRenderInformation* globalRenderInformation);
 
 void addSpeciesReferenceGlyphGlobalStyles(GlobalRenderInformation* globalRenderInformation);
@@ -213,6 +217,8 @@ void setCompartmentGlyphTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
 void setSpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
+void setEmptySpeciesGlyphRenderGroupFeatures(RenderGroup* renderGroup);
+
 void setSpeciesGlyphTextGlyphRenderGroupFeatures(RenderGroup* renderGroup);
 
 void setReactionGlyphRenderGroupFeatures(RenderGroup* renderGroup);
@@ -246,6 +252,8 @@ void setDefaultOctagonShapeFeatures(Polygon* pentagon);
 void setDefaultRenderCurveShapeFeatures(RenderCurve* renderCurve);
 
 void setDefaultImageShapeFeatures(Image* image);
+
+void setDefaultDiagonalRenderCurveFeatures(RenderCurve* renderCurve);
 
 void unifyGeometricShapeMutualFeatures(RenderGroup* renderGroup);
 

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -628,11 +628,11 @@ double getSpeciesReferenceCurveSegmentStartPointX(SBMLDocument* document, unsign
 }
 
 int setSpeciesReferenceCurveSegmentStartPointX(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentStartPointX(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex), curveSegmentIndex, x);
+    return setCurveSegmentStartPointX(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, x);
 }
 
 int setSpeciesReferenceCurveSegmentStartPointX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentStartPointX(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex), curveSegmentIndex, x);
+    return setCurveSegmentStartPointX(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, x);
 }
 
 int setSpeciesReferenceCurveSegmentStartPointX(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
@@ -652,11 +652,11 @@ double getSpeciesReferenceCurveSegmentStartPointY(SBMLDocument* document, unsign
 }
 
 int setSpeciesReferenceCurveSegmentStartPointY(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentStartPointY(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentStartPointY(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentStartPointY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentStartPointY(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentStartPointY(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentStartPointY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
@@ -676,12 +676,11 @@ double getSpeciesReferenceCurveSegmentEndPointX(SBMLDocument* document, unsigned
 }
 
 int setSpeciesReferenceCurveSegmentEndPointX(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentEndPointX(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex),
-                               curveSegmentIndex, x);
+    return setCurveSegmentEndPointX(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, x);
 }
 
 int setSpeciesReferenceCurveSegmentEndPointX(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentEndPointX(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex),
+    return setCurveSegmentEndPointX(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex),
                                curveSegmentIndex, x);
 }
 
@@ -702,11 +701,11 @@ double getSpeciesReferenceCurveSegmentEndPointY(SBMLDocument* document, unsigned
 }
 
 int setSpeciesReferenceCurveSegmentEndPointY(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentEndPointY(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentEndPointY(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentEndPointY(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentEndPointY(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentEndPointY(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentEndPointY(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
@@ -726,11 +725,11 @@ double getSpeciesReferenceCurveSegmentBasePoint1X(SBMLDocument* document, unsign
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentBasePoint1X(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex), curveSegmentIndex, x);
+    return setCurveSegmentBasePoint1X(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, x);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint1X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentBasePoint1X(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex), curveSegmentIndex, x);
+    return setCurveSegmentBasePoint1X(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, x);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint1X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
@@ -750,11 +749,11 @@ double getSpeciesReferenceCurveSegmentBasePoint1Y(SBMLDocument* document, unsign
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentBasePoint1Y(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentBasePoint1Y(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint1Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentBasePoint1Y(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentBasePoint1Y(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint1Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
@@ -774,11 +773,11 @@ double getSpeciesReferenceCurveSegmentBasePoint2X(SBMLDocument* document, unsign
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentBasePoint2X(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex), curveSegmentIndex, x);
+    return setCurveSegmentBasePoint2X(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, x);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint2X(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
-    return setCurveSegmentBasePoint2X(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex), curveSegmentIndex, x);
+    return setCurveSegmentBasePoint2X(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, x);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint2X(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& x) {
@@ -798,11 +797,11 @@ double getSpeciesReferenceCurveSegmentBasePoint2Y(SBMLDocument* document, unsign
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentBasePoint2Y(getSpeciesReference(getLayout(document), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentBasePoint2Y(getSpeciesReference(getLayout(document), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint2Y(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {
-    return setCurveSegmentBasePoint2Y(getSpeciesReference(getLayout(document, layoutIndex), reactionId, speciesReferenceIndex), curveSegmentIndex, y);
+    return setCurveSegmentBasePoint2Y(getSpeciesReference(getLayout(document, layoutIndex), reactionId, 0, speciesReferenceIndex), curveSegmentIndex, y);
 }
 
 int setSpeciesReferenceCurveSegmentBasePoint2Y(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex, unsigned int curveSegmentIndex, const double& y) {

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -483,6 +483,22 @@ const std::string getSpeciesReferenceSpeciesGlyphId(SBMLDocument* document, unsi
     return getSpeciesReferenceSpeciesGlyphId(getLayout(document, layoutIndex), reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }
 
+bool isSetSpeciesReferenceEmptySpeciesGlyph(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetEmptySpeciesGlyph(getLayout(document), reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+bool isSetSpeciesReferenceEmptySpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return isSetEmptySpeciesGlyph(getLayout(document, layoutIndex), reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+const std::string getSpeciesReferenceEmptySpeciesGlyphId(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getEmptySpeciesGlyphId(getLayout(document), reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
+const std::string getSpeciesReferenceEmptySpeciesGlyphId(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
+    return getEmptySpeciesGlyphId(getLayout(document, layoutIndex), reactionId, reactionGlyphIndex, speciesReferenceIndex);
+}
+
 bool isSetSpeciesReferenceRole(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex) {
     return isSetRole(getLayout(document), reactionId, reactionGlyphIndex, speciesReferenceIndex);
 }

--- a/src/libsbmlnetwork_sbmldocument_layout.h
+++ b/src/libsbmlnetwork_sbmldocument_layout.h
@@ -687,6 +687,42 @@ LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceSpeciesGlyphId(SBMLDo
 /// the SpeciesReference does not exits or the object is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceSpeciesGlyphId(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex = 0, unsigned int speciesReferenceIndex = 0);
 
+/// @brief Predicate returning true if the SpeciesGlyph associated with the SpeciesReferenceGlyph with the given index in the given ReactionGlyph object with the given index associated with the entered reaction id is an empty SpeciesGlyph.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId the id of the reaction the number of SpeciesReference objects of its ReactionGlyph object with the given index associated with it is going to be returned.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object to return.
+/// @param speciesReferenceIndex the index of the SpeciesReference.
+/// @return @c true if the SpeciesGlyph associated with the SpeciesReferenceGlyph object with the given index is an empty SpeciesGlyph, @c false if either the SpeciesGlyph is not empty or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceEmptySpeciesGlyph(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+/// @brief Predicate returning true if the SpeciesGlyph associated with the SpeciesReferenceGlyph with the given index in the given ReactionGlyph object with the given index associated with the entered reaction id is an empty SpeciesGlyph.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout to return.
+/// @param reactionId the id of the reaction the number of SpeciesReference objects of its ReactionGlyph object with the given index associated with it is going to be returned.
+/// @param reactionGlyphIndex the index of the ReactionGlyph.
+/// @param speciesReferenceIndex the index of the SpeciesReference.
+/// @return @c true if the SpeciesGlyph associated with the SpeciesReferenceGlyph object with the given index is an empty SpeciesGlyph, @c false if either the SpeciesGlyph is not empty or the object is @c NULL.
+LIBSBMLNETWORK_EXTERN bool isSetSpeciesReferenceEmptySpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+/// @brief Returns the id of the empty species glyph associated with the SpeciesReference object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
+/// of the first Layout object in the ListOfLayouts of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param reactionId the id of the reaction the number of SpeciesReference objects of its ReactionGlyph object with the given index associated with it is going to be returned.
+/// @param reactionGlyphIndex the index number of the ReactionGlyph object to return.
+/// @param speciesReferenceIndex the index of the SpeciesReference.
+/// @return the id of the empty SpeciesGlyph associated with the SpeciesReference object with the given index, or @c "" if the SpeciesGlyph is not empty or the object is @c NULL
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceEmptySpeciesGlyphId(SBMLDocument* document, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
+/// @brief Returns the id of the empty species glyph associated with the SpeciesReference object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
+/// of the the Layout object with the given index in the ListOfLayouts of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout to return.
+/// @param reactionId the id of the reaction the number of SpeciesReference objects of its ReactionGlyph object with the given index associated with it is going to be returned.
+/// @param reactionGlyphIndex the index of the ReactionGlyph.
+/// @param speciesReferenceIndex the index of the SpeciesReference.
+/// @return the id of the empty SpeciesGlyph associated with the SpeciesReference object with the given index, or @c "" if the SpeciesGlyph is not empty or the object is @c NULL
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesReferenceEmptySpeciesGlyphId(SBMLDocument* document, unsigned int layoutIndex, const std::string& reactionId, unsigned int reactionGlyphIndex, unsigned int speciesReferenceIndex);
+
 /// @brief Predicates returning @c true if the "role" attribute of the SpeciesReference object with the given index of the ReactionGlyph object with the given index associated with the entered reaction id
 /// of the first Layout object in the ListOfLayouts of the SBML document is set.
 /// @param document a pointer to the SBMLDocument object.


### PR DESCRIPTION
# Pull Request Description

## Changes Summary
- **Fixed autolayout issue** causing incorrect offsetting of reaction center points.
- **Corrected arguments** for the `getSpeciesReference` function.
- **Introduced `updateCurves` flag** in node update functions (C & Python).
- **Replaced dummy species glyph** with an empty species glyph and added related API functions.
- **Refactored SBMLNetwork object handling** to pass the libsbmlnetwork object directly to `networkInfoTranslator`.
