### PR TITLE
Fix minor bugs

### DIFF
--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -399,7 +399,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param graphicalObjectIndex the index number of the GraphicalObject to return.
     /// @param layoutIndex the index number of the Layout to return.
     /// @return the id of the compartment associated with the given GraphicalObject, or @c "" if the object does not exists.
-    LIBSBMLNETWORK_EXTERN const char* c_api_getCGraphicalObjectCompartmentId(SBMLDocument* document, const char* id, int graphicalObjectIndex = 0, int layoutIndex = 0);
+    LIBSBMLNETWORK_EXTERN const char* c_api_getGraphicalObjectCompartmentId(SBMLDocument* document, const char* id, int graphicalObjectIndex = 0, int layoutIndex = 0);
 
     /// @brief Returns the number of Species objects in the given SBML document.
     /// @param document a pointer to the SBMLDocument object.

--- a/src/features/hide_elements/libsbmlnetwork_hide_elements.cpp
+++ b/src/features/hide_elements/libsbmlnetwork_hide_elements.cpp
@@ -1,6 +1,7 @@
 #include "libsbmlnetwork_hide_elements.h"
 #include "../../libsbmlnetwork_sbmldocument_layout.h"
 #include "../../libsbmlnetwork_layout.h"
+#include "../../libsbmlnetwork_layout_helpers.h"
 #include "../../libsbmlnetwork_sbmldocument_render.h"
 #include "../../libsbmlnetwork_render.h"
 #include "../../libsbmlnetwork_render_helpers.h"
@@ -297,15 +298,19 @@ int hide_elements_makeSpeciesGlyphVisible(SBMLDocument* document, SpeciesGlyph* 
         Style* style = getLocalStyle(document, speciesGlyph);
         if (!style)
             style = createLocalStyle(document, speciesGlyph);
+        Layout* layout = getLayout(document);
         hide_elements_make2DGraphicalObjectVisible(document, style);
-        std::vector<TextGlyph*> textGlyphs = getTextGlyphs(getLayout(document), speciesGlyph);
+        std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, speciesGlyph);
         for (std::vector<TextGlyph*>::const_iterator textGlyphIt = textGlyphs.cbegin(); textGlyphIt != textGlyphs.cend(); textGlyphIt++)
             hide_elements_makeTextGlyphVisible(document, *textGlyphIt, speciesGlyph);
         if (applyToConnectedElements) {
-            std::vector<SpeciesReferenceGlyph*> speciesReferenceGlyphs = set_layout_features_getConnectedSpeciesGlyphReferences(getLayout(document), speciesGlyph);
+            std::vector<SpeciesReferenceGlyph*> speciesReferenceGlyphs = set_layout_features_getConnectedSpeciesGlyphReferences(layout, speciesGlyph);
             for (std::vector<SpeciesReferenceGlyph*>::const_iterator speciesReferenceGlyphIt = speciesReferenceGlyphs.cbegin(); speciesReferenceGlyphIt != speciesReferenceGlyphs.cend(); speciesReferenceGlyphIt++) {
                 if (hide_elements_makeSpeciesReferenceGlyphVisible(document, *speciesReferenceGlyphIt))
                     return -1;
+                ReactionGlyph* reactionGlyph = findSpeciesReferenceReactionGlyph(layout, *speciesReferenceGlyphIt);
+                if (isUniUniReaction(document->getModel(), reactionGlyph))
+                    hide_elements_makeReactionGlyphVisible(document, reactionGlyph, true);
             }
         }
 
@@ -320,15 +325,19 @@ int hide_elements_makeSpeciesGlyphInvisible(SBMLDocument* document, SpeciesGlyph
         Style* style = getLocalStyle(document, speciesGlyph);
         if (!style)
             style = createLocalStyle(document, speciesGlyph);
+        Layout* layout = getLayout(document);
         hide_elements_make2DGraphicalObjectInvisible(document, style);
-        std::vector<TextGlyph*> textGlyphs = getTextGlyphs(getLayout(document), speciesGlyph);
+        std::vector<TextGlyph*> textGlyphs = getTextGlyphs(layout, speciesGlyph);
         for (std::vector<TextGlyph*>::const_iterator textGlyphIt = textGlyphs.cbegin(); textGlyphIt != textGlyphs.cend(); textGlyphIt++)
             hide_elements_makeTextGlyphInvisible(document, *textGlyphIt, speciesGlyph);
         if (applyToConnectedElements) {
-            std::vector<SpeciesReferenceGlyph*> speciesReferenceGlyphs = set_layout_features_getConnectedSpeciesGlyphReferences(getLayout(document), speciesGlyph);
+            std::vector<SpeciesReferenceGlyph*> speciesReferenceGlyphs = set_layout_features_getConnectedSpeciesGlyphReferences(layout, speciesGlyph);
             for (std::vector<SpeciesReferenceGlyph*>::const_iterator speciesReferenceGlyphIt = speciesReferenceGlyphs.cbegin(); speciesReferenceGlyphIt != speciesReferenceGlyphs.cend(); speciesReferenceGlyphIt++) {
                 if (hide_elements_makeSpeciesReferenceGlyphInvisible(document, *speciesReferenceGlyphIt))
                     return -1;
+                ReactionGlyph* reactionGlyph = findSpeciesReferenceReactionGlyph(layout, *speciesReferenceGlyphIt);
+                if (isUniUniReaction(document->getModel(), reactionGlyph))
+                    hide_elements_makeReactionGlyphInvisible(document, reactionGlyph, true);
             }
         }
 

--- a/src/features/set_layout_features/libsbmlnetwork_set_layout_features.cpp
+++ b/src/features/set_layout_features/libsbmlnetwork_set_layout_features.cpp
@@ -341,7 +341,7 @@ std::vector<SpeciesReferenceGlyph*> set_layout_features_getConnectedSpeciesGlyph
 
 const std::string set_layout_features_getCompartmentGlyphId(Layout* layout, const std::string compartmentId) {
     std::string compartmentGlyphId = "";
-    int compartmentGlyphIndex = 1;
+    int compartmentGlyphIndex = 0;
     std::vector<CompartmentGlyph*> compartmentGlyphs = getAssociatedCompartmentGlyphsWithCompartmentId(layout, compartmentId);
     while (true) {
         compartmentGlyphId = compartmentId + "_Glyph_" + std::to_string(compartmentGlyphIndex++);
@@ -361,7 +361,7 @@ const std::string set_layout_features_getCompartmentGlyphId(Layout* layout, cons
 
 const std::string set_layout_features_getSpeciesGlyphId(Layout* layout, const std::string speciesId) {
     std::string speciesGlyphId = "";
-    int speciesGlyphIndex = 1;
+    int speciesGlyphIndex = 0;
     std::vector<SpeciesGlyph*> speciesGlyphs = getAssociatedSpeciesGlyphsWithSpeciesId(layout, speciesId);
     while (true) {
         speciesGlyphId = speciesId + "_Glyph_" + std::to_string(speciesGlyphIndex++);
@@ -381,7 +381,7 @@ const std::string set_layout_features_getSpeciesGlyphId(Layout* layout, const st
 
 const std::string set_layout_features_getReactionGlyphId(Layout* layout, const std::string reactionId) {
     std::string reactionGlyphId = "";
-    int reactionGlyphIndex = 1;
+    int reactionGlyphIndex = 0;
     std::vector<ReactionGlyph*> reactionGlyphs = getAssociatedReactionGlyphsWithReactionId(layout, reactionId);
     while (true) {
         reactionGlyphId = reactionId + "_Glyph_" + std::to_string(reactionGlyphIndex++);
@@ -401,9 +401,9 @@ const std::string set_layout_features_getReactionGlyphId(Layout* layout, const s
 
 const std::string set_layout_features_getSpeciesReferenceGlyphId(ReactionGlyph* reactionGlyph, const std::string speciesGlyphId, unsigned int stoichiometryIndex) {
     std::string speciesReferenceGlyphId = "";
-    int speciesReferenceGlyphIndex = 1;
+    int speciesReferenceGlyphIndex = 0;
     std::vector<SpeciesReferenceGlyph*> speciesReferenceGlyphs = getSpeciesReferenceGlyphs(reactionGlyph);
-    std::string stoichiometryPhrase = "_Stoichiometry_" + std::to_string(stoichiometryIndex + 1);
+    std::string stoichiometryPhrase = "_Stoichiometry_" + std::to_string(stoichiometryIndex);
     while (true) {
         speciesReferenceGlyphId = speciesGlyphId + "_" + reactionGlyph->getId() + stoichiometryPhrase + "_Glyph_" + std::to_string(speciesReferenceGlyphIndex++);
         bool isUniqueId = true;

--- a/src/libsbmlnetwork_layout_helpers.cpp
+++ b/src/libsbmlnetwork_layout_helpers.cpp
@@ -301,13 +301,18 @@ SimpleSpeciesReference* findSpeciesReference(Model* model, Layout* layout, React
     return NULL;
 }
 
-bool containsSpecies(Model* model, Layout* layout, CompartmentGlyph* compartmentGlyph) {
-    std::string compartmentId = compartmentGlyph->getCompartmentId();
-    for (unsigned int i = 0; i < model->getNumSpecies(); i++)
-        if (model->getSpecies(i)->getCompartment() == compartmentId)
-            return true;
-    
-    return false;
+ReactionGlyph* findSpeciesReferenceReactionGlyph(Layout* layout, SpeciesReferenceGlyph* speciesReferenceGlyph) {
+    if (layout) {
+        for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
+            ReactionGlyph* reactionGlyph = layout->getReactionGlyph(i);
+            for (unsigned int j = 0; j < reactionGlyph->getNumSpeciesReferenceGlyphs(); j++) {
+                if (reactionGlyph->getSpeciesReferenceGlyph(j) == speciesReferenceGlyph)
+                    return reactionGlyph;
+            }
+        }
+    }
+
+    return NULL;
 }
 
 bool compartmentGlyphBelongs(CompartmentGlyph* compartmentGlyph, Compartment* compartment) {
@@ -335,19 +340,6 @@ const std::string getSpeciesReferenceGlyphSpeciesId(Layout* layout, SpeciesRefer
 bool textGlyphBelongs(TextGlyph* textGlyph, GraphicalObject* graphicalObject) {
     if (textGlyph && graphicalObject)
         return textGlyph->getGraphicalObjectId() == graphicalObject->getId() ? true : false;
-
-    return false;
-}
-
-bool graphicalObjectBelongsToReactionGlyph(ReactionGlyph* reactionGlyph, GraphicalObject* graphicalObject) {
-    if (graphicalObject) {
-        for (unsigned int i = 0; i < reactionGlyph->getNumSpeciesReferenceGlyphs(); i++) {
-            if (reactionGlyph->getSpeciesReferenceGlyph(i) == graphicalObject)
-                return true;
-            else if (reactionGlyph->getSpeciesReferenceGlyph(i)->getSpeciesGlyphId() == graphicalObject->getId())
-                return true;
-        }
-    }
 
     return false;
 }
@@ -491,7 +483,7 @@ std::vector<SpeciesReferenceGlyph*> getSpeciesReferenceGlyphs(ReactionGlyph* rea
 
 const std::string getTextGlyphUniqueId(Layout* layout, GraphicalObject* graphicalObject) {
     std::string textGlyphUniqueId = "";
-    int textGlyphIndex = 1;
+    int textGlyphIndex = 0;
     std::vector<TextGlyph*> textGlyphs = getAssociatedTextGlyphsWithGraphicalObject(layout, graphicalObject);
     while (true) {
         textGlyphUniqueId = graphicalObject->getId() + "_TextGlyph_" + std::to_string(textGlyphIndex++);
@@ -523,8 +515,16 @@ const bool layoutContainsGlyphs(Layout* layout) {
            (layout->getNumReactionGlyphs() > 0);
 }
 
-const bool isGraphicalObject(SBase* sbase) {
-    return dynamic_cast<GraphicalObject*>(sbase) ? true : false;
+const bool isGraphicalObject(SBase* sBase) {
+    return dynamic_cast<GraphicalObject*>(sBase) != nullptr;
+}
+
+const bool isUniUniReaction(Model* model, ReactionGlyph* reactionGlyph) {
+    return isUniUniReaction(findReactionGlyphReaction(model, reactionGlyph));
+}
+
+const bool isUniUniReaction(Reaction* reaction) {
+    return reaction && reaction->getNumReactants() == 1 && reaction->getNumProducts() == 1;
 }
 
 const int getStoichiometryAsInteger(SimpleSpeciesReference* speciesReference) {

--- a/src/libsbmlnetwork_layout_helpers.h
+++ b/src/libsbmlnetwork_layout_helpers.h
@@ -66,6 +66,8 @@ Reaction* findReactionGlyphReaction(Model* model, ReactionGlyph* reactionGlyph);
 
 SimpleSpeciesReference* findSpeciesReference(Model* model, Layout* layout, ReactionGlyph* reactionGlyph, SpeciesGlyph* speciesGlyph);
 
+ReactionGlyph* findSpeciesReferenceReactionGlyph(Layout* layout, SpeciesReferenceGlyph* speciesReferenceGlyph);
+
 bool containsSpecies(Model* model, Layout* layout, CompartmentGlyph* compartmentGlyph);
 
 bool compartmentGlyphBelongs(CompartmentGlyph* compartmentGlyph, Compartment* compartment);
@@ -77,8 +79,6 @@ bool reactionGlyphBelongs(ReactionGlyph* reactionGlyph, Reaction* reaction);
 const std::string getSpeciesReferenceGlyphSpeciesId(Layout* layout, SpeciesReferenceGlyph* speciesReferenceGlyph);
 
 bool textGlyphBelongs(TextGlyph* textGlyph, GraphicalObject* graphicalObject);
-
-bool graphicalObjectBelongsToReactionGlyph(Layout* layout, ReactionGlyph* reactionGlyph, GraphicalObject* graphicalObject);
 
 std::vector<TextGlyph*> getAssociatedTextGlyphsWithGraphicalObject(Layout* layout, GraphicalObject* graphicalObject);
 
@@ -109,6 +109,10 @@ const std::string getIdOfSpeciesReferenceGlyphConnectedToNewSpeciesGlyph(std::st
 const bool layoutContainsGlyphs(Layout* layout);
 
 const bool isGraphicalObject(SBase* sbase);
+
+const bool isUniUniReaction(Model* model, ReactionGlyph* reactionGlyph);
+
+const bool isUniUniReaction(Reaction* reaction);
 
 const int getStoichiometryAsInteger(SimpleSpeciesReference* speciesReference);
 


### PR DESCRIPTION
- **Fix bug with function name**: Corrected the name of the `c_api_getGraphicalObjectCompartmentId` function.
  
- **Graphical object ID indexing**: The index for graphical object IDs now starts at 0.

- **Hide/unhide reaction feature**: The "hide" feature now hides or unhides the entire reaction when one of the species connected to a uni-uni reaction is hidden or unhidden.
