### PR TITLE
Allow various 'get' functions to work with const input.

### DIFF
--- a/src/features/error_log/libsbmlnetwork_error_log.cpp
+++ b/src/features/error_log/libsbmlnetwork_error_log.cpp
@@ -52,7 +52,7 @@ void error_log_clearErrorLog(SBMLDocument* document) {
     }
 }
 
-const std::string error_log_getErrorLog(Layout* layout) {
+const std::string error_log_getErrorLog(const Layout* layout) {
     std::string errorLog = "";
     if (layout) {
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(layout, "error_log"), errorLog);
@@ -89,14 +89,14 @@ void error_log_clearErrorLog(Layout* layout) {
     }
 }
 
-const std::string error_log_getErrorLog(GraphicalObject* graphicalObject) {
+const std::string error_log_getErrorLog(const GraphicalObject* graphicalObject) {
     std::string errorLog = "";
     if (graphicalObject)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(graphicalObject, "error_log"), errorLog);
     if (graphicalObject->getBoundingBox())
         errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(graphicalObject->getBoundingBox()), errorLog);
     if (isSetCurve(graphicalObject))
-        errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(getCurve(graphicalObject)), errorLog);
+        errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(getCurve(const_cast<GraphicalObject*>(graphicalObject))), errorLog);
 
     return errorLog;
 }
@@ -111,7 +111,7 @@ void error_log_clearErrorLog(GraphicalObject* graphicalObject) {
     }
 }
 
-const std::string error_log_getErrorLog(BoundingBox* boundingBox) {
+const std::string error_log_getErrorLog(const BoundingBox* boundingBox) {
     std::string errorLog = "";
     if (boundingBox)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(boundingBox, "error_log"), errorLog);
@@ -124,12 +124,12 @@ void error_log_clearErrorLog(BoundingBox* boundingBox) {
         user_data_setUserData(boundingBox, "error_log", "");
 }
 
-const std::string error_log_getErrorLog(Curve* curve) {
+const std::string error_log_getErrorLog(const Curve* curve) {
     std::string errorLog = "";
     if (curve)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(curve, "error_log"), errorLog);
     for (unsigned int i = 0; i < getNumCurveSegments(curve); i++)
-        errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(getCurveSegment(curve, i)), errorLog);
+        errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(getCurveSegment(const_cast<Curve*>(curve), i)), errorLog);
 
     return errorLog;
 }
@@ -142,7 +142,7 @@ void error_log_clearErrorLog(Curve* curve) {
     }
 }
 
-const std::string error_log_getErrorLog(LineSegment* lineSegment) {
+const std::string error_log_getErrorLog(const LineSegment* lineSegment) {
     std::string errorLog = "";
     if (lineSegment)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(lineSegment, "error_log"), errorLog);
@@ -155,14 +155,14 @@ void error_log_clearErrorLog(LineSegment* lineSegment) {
         user_data_setUserData(lineSegment, "error_log", "");
 }
 
-const std::string error_log_getErrorLog(RenderInformationBase* renderInformation) {
+const std::string error_log_getErrorLog(const RenderInformationBase* renderInformation) {
     std::string errorLog = "";
     if (renderInformation)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(renderInformation, "error_log"), errorLog);
     for (unsigned int i = 0; i < renderInformation->getNumColorDefinitions(); i++)
         errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(renderInformation->getColorDefinition(i)), errorLog);
     for (unsigned int i = 0; i < renderInformation->getNumGradientDefinitions(); i++) {
-        GradientBase* gradientBase = renderInformation->getGradientDefinition(i);
+        const GradientBase* gradientBase = renderInformation->getGradientDefinition(i);
         errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(gradientBase), errorLog);
         for (unsigned int j = 0; j < gradientBase->getNumGradientStops(); j++)
             errorLog += error_log_prepareErrorMessage(error_log_getErrorLog(gradientBase->getGradientStop(j)), errorLog);
@@ -205,7 +205,7 @@ void error_log_clearErrorLog(RenderInformationBase* renderInformation) {
     }
 }
 
-const std::string error_log_getErrorLog(ColorDefinition* colorDefinition) {
+const std::string error_log_getErrorLog(const ColorDefinition* colorDefinition) {
     std::string errorLog = "";
     if (colorDefinition)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(colorDefinition, "error_log"), errorLog);
@@ -218,7 +218,7 @@ void error_log_clearErrorLog(ColorDefinition* colorDefinition) {
         user_data_setUserData(colorDefinition, "error_log", "");
 }
 
-const std::string error_log_getErrorLog(GradientBase* gradientBase) {
+const std::string error_log_getErrorLog(const GradientBase* gradientBase) {
     std::string errorLog = "";
     if (gradientBase)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(gradientBase, "error_log"), errorLog);
@@ -231,7 +231,7 @@ void error_log_clearErrorLog(GradientBase* gradientBase) {
         user_data_setUserData(gradientBase, "error_log", "");
 }
 
-const std::string error_log_getErrorLog(GradientStop* gradientStop) {
+const std::string error_log_getErrorLog(const GradientStop* gradientStop) {
     std::string errorLog = "";
     if (gradientStop)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(gradientStop, "error_log"), errorLog);
@@ -244,7 +244,7 @@ void error_log_clearErrorLog(GradientStop* gradientStop) {
         user_data_setUserData(gradientStop, "error_log", "");
 }
 
-const std::string error_log_getErrorLog(LineEnding* lineEnding) {
+const std::string error_log_getErrorLog(const LineEnding* lineEnding) {
     std::string errorLog = "";
     if (lineEnding)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(lineEnding, "error_log"), errorLog);
@@ -257,7 +257,7 @@ void error_log_clearErrorLog(LineEnding* lineEnding) {
         user_data_setUserData(lineEnding, "error_log", "");
 }
 
-const std::string error_log_getErrorLog(Style* style) {
+const std::string error_log_getErrorLog(const Style* style) {
     std::string errorLog = "";
     if (style) {
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(style, "error_log"), errorLog);
@@ -274,7 +274,7 @@ void error_log_clearErrorLog(Style* style) {
     }
 }
 
-const std::string error_log_getErrorLog(RenderGroup* renderGroup) {
+const std::string error_log_getErrorLog(const RenderGroup* renderGroup) {
     std::string errorLog = "";
     if (renderGroup) {
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(renderGroup, "error_log"), errorLog);
@@ -293,7 +293,7 @@ void error_log_clearErrorLog(RenderGroup* renderGroup) {
     }
 }
 
-const std::string error_log_getErrorLog(Transformation2D* transformation2D) {
+const std::string error_log_getErrorLog(const Transformation2D* transformation2D) {
     std::string errorLog = "";
     if (transformation2D)
         errorLog += error_log_prepareErrorMessage(user_data_getUserData(transformation2D, "error_log"), errorLog);
@@ -306,7 +306,7 @@ void error_log_clearErrorLog(Transformation2D* transformation2D) {
         user_data_setUserData(transformation2D, "error_log", "");
 }
 
-const std::string error_log_getErrorLog(SBase* sBase) {
+const std::string error_log_getErrorLog(const SBase* sBase) {
     std::string errorLog = "";
     if (sBase)
         errorLog = error_log_prepareErrorMessage(user_data_getUserData(sBase, "error_log"), errorLog);

--- a/src/features/error_log/libsbmlnetwork_error_log.h
+++ b/src/features/error_log/libsbmlnetwork_error_log.h
@@ -11,59 +11,59 @@ using namespace libsbml;
 
 namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 
-const std::string error_log_getErrorLog(Layout *layout);
+const std::string error_log_getErrorLog(const Layout *layout);
 
 void error_log_clearErrorLog(Layout *layout);
 
-const std::string error_log_getErrorLog(GraphicalObject *graphicalObject);
+const std::string error_log_getErrorLog(const GraphicalObject *graphicalObject);
 
 void error_log_clearErrorLog(GraphicalObject *graphicalObject);
 
-const std::string error_log_getErrorLog(BoundingBox *boundingBox);
+const std::string error_log_getErrorLog(const BoundingBox *boundingBox);
 
 void error_log_clearErrorLog(BoundingBox *boundingBox);
 
-const std::string error_log_getErrorLog(Curve *curve);
+const std::string error_log_getErrorLog(const Curve *curve);
 
 void error_log_clearErrorLog(Curve *curve);
 
-const std::string error_log_getErrorLog(LineSegment *lineSegment);
+const std::string error_log_getErrorLog(const LineSegment *lineSegment);
 
 void error_log_clearErrorLog(LineSegment *lineSegment);
 
-const std::string error_log_getErrorLog(RenderInformationBase* renderInformation);
+const std::string error_log_getErrorLog(const RenderInformationBase* renderInformation);
 
 void error_log_clearErrorLog(RenderInformationBase* renderInformation);
 
-const std::string error_log_getErrorLog(ColorDefinition* colorDefinition);
+const std::string error_log_getErrorLog(const ColorDefinition* colorDefinition);
 
 void error_log_clearErrorLog(ColorDefinition* colorDefinition);
 
-const std::string error_log_getErrorLog(GradientBase* gradientBase);
+const std::string error_log_getErrorLog(const GradientBase* gradientBase);
 
 void error_log_clearErrorLog(GradientBase* gradientBase);
 
-const std::string error_log_getErrorLog(GradientStop* gradientStop);
+const std::string error_log_getErrorLog(const GradientStop* gradientStop);
 
 void error_log_clearErrorLog(GradientStop* gradientStop);
 
-const std::string error_log_getErrorLog(LineEnding* lineEnding);
+const std::string error_log_getErrorLog(const LineEnding* lineEnding);
 
 void error_log_clearErrorLog(LineEnding* lineEnding);
 
-const std::string error_log_getErrorLog(Style* style);
+const std::string error_log_getErrorLog(const Style* style);
 
 void error_log_clearErrorLog(Style* style);
 
-const std::string error_log_getErrorLog(RenderGroup* renderGroup);
+const std::string error_log_getErrorLog(const RenderGroup* renderGroup);
 
 void error_log_clearErrorLog(RenderGroup* renderGroup);
 
-const std::string error_log_getErrorLog(Transformation2D* transformation2D);
+const std::string error_log_getErrorLog(const Transformation2D* transformation2D);
 
 void error_log_clearErrorLog(Transformation2D* transformation2D);
 
-const std::string error_log_getErrorLog(SBase* sBase);
+const std::string error_log_getErrorLog(const SBase* sBase);
 
 void error_log_clearErrorLog(SBase* sBase);
 

--- a/src/features/user_data/libsbmlnetwork_user_data.cpp
+++ b/src/features/user_data/libsbmlnetwork_user_data.cpp
@@ -51,7 +51,7 @@ int user_data_freeUserData(Layout* layout) {
     return 0;
 }
 
-std::vector<std::map<std::string, std::string>> user_data_getUserData(Layout* layout) {
+std::vector<std::map<std::string, std::string>> user_data_getUserData(const Layout* layout) {
     std::vector<std::map<std::string, std::string>> userData;
     for (unsigned int i = 0; i < layout->getNumCompartmentGlyphs(); i++) {
         auto compartmentGlyphUserData = layout->getCompartmentGlyph(i)->getUserData();
@@ -198,7 +198,7 @@ int user_data_freeUserData(RenderInformationBase* renderInformation) {
     return 0;
 }
 
-std::vector<std::map<std::string, std::string>> user_data_getUserData(RenderInformationBase* renderInformation) {
+std::vector<std::map<std::string, std::string>> user_data_getUserData(const RenderInformationBase* renderInformation) {
     std::vector<std::map<std::string, std::string>> userData;
     for (unsigned int i = 0; i < renderInformation->getNumColorDefinitions(); i++) {
         auto colorDefinitionUserData = renderInformation->getColorDefinition(i)->getUserData();

--- a/src/features/user_data/libsbmlnetwork_user_data.cpp
+++ b/src/features/user_data/libsbmlnetwork_user_data.cpp
@@ -233,7 +233,7 @@ std::vector<std::map<std::string, std::string>> user_data_getUserData(const Rend
     return userData;
 }
 
-const std::string user_data_getUserData(SBase* sBase, const std::string& key) {
+const std::string user_data_getUserData(const SBase* sBase, const std::string& key) {
     if (sBase && sBase->isSetUserData()) {
         auto userData = (std::map<std::string, std::string>*)sBase->getUserData();
         if (userData->find(key) != userData->end())

--- a/src/features/user_data/libsbmlnetwork_user_data.h
+++ b/src/features/user_data/libsbmlnetwork_user_data.h
@@ -15,7 +15,7 @@ int user_data_freeUserData(SBMLDocument* document);
 
 int user_data_freeUserData(Layout* layout);
 
-std::vector<std::map<std::string, std::string>> user_data_getUserData(Layout* layout);
+std::vector<std::map<std::string, std::string>> user_data_getUserData(const Layout* layout);
 
 int user_data_setUserData(GraphicalObject* graphicalObject, const std::string& key, const std::string& value);
 
@@ -31,9 +31,9 @@ int user_data_setGraphicalObjectUserData(GraphicalObject* graphicalObject, const
 
 int user_data_freeUserData(RenderInformationBase* renderInformation);
 
-std::vector<std::map<std::string, std::string>> user_data_getUserData(RenderInformationBase* renderInformationBase);
+std::vector<std::map<std::string, std::string>> user_data_getUserData(const RenderInformationBase* renderInformationBase);
 
-const std::string user_data_getUserData(SBase* sbase, const std::string& key);
+const std::string user_data_getUserData(const SBase* sbase, const std::string& key);
 
 int user_data_setUserData(SBase* sBase, const std::string& key, const std::string& value);
 

--- a/src/libsbmlnetwork_layout.cpp
+++ b/src/libsbmlnetwork_layout.cpp
@@ -380,12 +380,12 @@ const std::string getReactionId(GraphicalObject* reactionGlyph) {
     return "";
 }
 
-bool isReactionGlyph(Layout* layout, const std::string& id, const unsigned int reactionGlyphIndex) {
-    return isReactionGlyph(getReactionGlyph(layout, id, reactionGlyphIndex));
+bool isReactionGlyph(const Layout* layout, const std::string& id, const unsigned int reactionGlyphIndex) {
+    return isReactionGlyph(getReactionGlyph(const_cast<Layout*>(layout), id, reactionGlyphIndex));
 }
 
-bool isReactionGlyph(GraphicalObject* graphicalObject) {
-    if (dynamic_cast<ReactionGlyph*>(graphicalObject))
+bool isReactionGlyph(const GraphicalObject* graphicalObject) {
+    if (dynamic_cast<const ReactionGlyph*>(graphicalObject))
         return true;
 
     return false;
@@ -552,8 +552,8 @@ const int getSpeciesReferenceIndexAssociatedWithSpecies(Layout* layout, const st
     return -1;
 }
 
-bool isSpeciesReferenceGlyph(GraphicalObject* graphicalObject) {
-    if (dynamic_cast<SpeciesReferenceGlyph*>(graphicalObject))
+bool isSpeciesReferenceGlyph(const GraphicalObject* graphicalObject) {
+    if (dynamic_cast<const SpeciesReferenceGlyph*>(graphicalObject))
         return true;
 
     return false;
@@ -617,11 +617,11 @@ bool isSetText(GraphicalObject* textGlyph) {
     return false;
 }
 
-const std::string getText(Layout* layout, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
-    return getText(getTextGlyph(layout, getGraphicalObject(layout, id, graphicalObjectIndex), textGlyphIndex));
+const std::string getText(const Layout* layout, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
+    return getText(getTextGlyph(const_cast<Layout*>(layout), getGraphicalObject(const_cast<Layout*>(layout), id, graphicalObjectIndex), textGlyphIndex));
 }
 
-const std::string getText(GraphicalObject* textGlyph) {
+const std::string getText(const GraphicalObject* textGlyph) {
     if (isTextGlyph(textGlyph))
         return ((TextGlyph*)textGlyph)->getText();
 
@@ -758,12 +758,12 @@ GraphicalObject* getGraphicalObject(Layout* layout, GraphicalObject* textGlyph) 
     return getGraphicalObjectUsingItsOwnId(layout, getGraphicalObjectId(textGlyph));
 }
 
-bool isTextGlyph(Layout* layout, const std::string& id, unsigned int textGlyphIndex) {
-    return isTextGlyph(getTextGlyph(layout, id, textGlyphIndex));
+bool isTextGlyph(const Layout* layout, const std::string& id, unsigned int textGlyphIndex) {
+    return isTextGlyph(getTextGlyph(const_cast<Layout*>(layout), id, textGlyphIndex));
 }
 
-bool isTextGlyph(GraphicalObject* graphicalObject) {
-    if (dynamic_cast<TextGlyph*>(graphicalObject))
+bool isTextGlyph(const GraphicalObject* graphicalObject) {
+    if (dynamic_cast<const TextGlyph*>(graphicalObject))
         return true;
 
     return false;
@@ -1243,11 +1243,11 @@ int setTextDimensionHeight(Layout* layout, GraphicalObject* graphicalObject, uns
     return -1;
 }
 
-bool isSetCurve(Layout* layout, const std::string& id, unsigned int graphicalObjectIndex) {
-    return isSetCurve(getGraphicalObject(layout, id, graphicalObjectIndex));
+bool isSetCurve(const Layout* layout, const std::string& id, unsigned int graphicalObjectIndex) {
+    return isSetCurve(getGraphicalObject(const_cast<Layout*>(layout), id, graphicalObjectIndex));
 }
 
-bool isSetCurve(GraphicalObject* graphicalObject) {
+bool isSetCurve(const GraphicalObject* graphicalObject) {
     if (isReactionGlyph(graphicalObject))
         return ((ReactionGlyph*)graphicalObject)->isSetCurve();
     if (isSpeciesReferenceGlyph(graphicalObject))
@@ -1276,15 +1276,15 @@ int removeCurve(GraphicalObject* graphicalObject) {
     return -1;
 }
 
-const unsigned int getNumCurveSegments(Layout* layout, const std::string& id, unsigned int graphicalObjectIndex) {
-    return getNumCurveSegments(getGraphicalObject(layout, id, graphicalObjectIndex));
+const unsigned int getNumCurveSegments(const Layout* layout, const std::string& id, unsigned int graphicalObjectIndex) {
+    return getNumCurveSegments(getGraphicalObject(const_cast<Layout*>(layout), id, graphicalObjectIndex));
 }
 
-const unsigned int getNumCurveSegments(GraphicalObject* graphicalObject) {
-    return getNumCurveSegments(getCurve(graphicalObject));
+const unsigned int getNumCurveSegments(const GraphicalObject* graphicalObject) {
+    return getNumCurveSegments(getCurve(const_cast<GraphicalObject*>(graphicalObject)));
 }
 
-const unsigned int getNumCurveSegments(Curve* curve) {
+const unsigned int getNumCurveSegments(const Curve* curve) {
     if (curve)
         return curve->getNumCurveSegments();
 

--- a/src/libsbmlnetwork_layout.h
+++ b/src/libsbmlnetwork_layout.h
@@ -332,12 +332,12 @@ LIBSBMLNETWORK_EXTERN const std::string getReactionId(GraphicalObject* reactionG
 /// @param id the id of the reaction the the ReactionGlyph objects of which to be returned.
 /// @param reactionGlyphIndex the index of the ReactionGlyph to return.
 /// @return @c true if this abstract GraphicalObject is of type ReactionGlyph, false otherwise
-LIBSBMLNETWORK_EXTERN bool isReactionGlyph(Layout* layout, const std::string& id, const unsigned int reactionGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN bool isReactionGlyph(const Layout* layout, const std::string& id, const unsigned int reactionGlyphIndex = 0);
 
 /// @brief Predicate returning true if this abstract GraphicalObject is of type ReactionGlyph.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @return @c true if this abstract GraphicalObject is of type ReactionGlyph, false otherwise
-LIBSBMLNETWORK_EXTERN bool isReactionGlyph(GraphicalObject* graphicalObject);
+LIBSBMLNETWORK_EXTERN bool isReactionGlyph(const GraphicalObject* graphicalObject);
 
 /// @brief Returns the number of SpeciesReference objects of the ReactionGlyph with the given index associated with the reaction with the given id of the Layout object.
 /// @param Layout a pointer to the Layout object.
@@ -525,7 +525,7 @@ LIBSBMLNETWORK_EXTERN const int getSpeciesReferenceIndexAssociatedWithSpecies(La
 /// @brief Predicate returning true if this abstract GraphicalObject object is of type SpeciesReferenceGlyph.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @return @c true if this abstract GraphicalObject object is of type SpeciesReferenceGlyph, false otherwise
-LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceGlyph(GraphicalObject* graphicalObject);
+LIBSBMLNETWORK_EXTERN bool isSpeciesReferenceGlyph(const GraphicalObject* graphicalObject);
 
 /// @brief Returns the number of TextGlyph objects of the Layout object.
 /// @param Layout a pointer to the Layout object.
@@ -591,13 +591,13 @@ LIBSBMLNETWORK_EXTERN bool isSetText(GraphicalObject* textGlyph);
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return the "text" attribute of this TextGlyph object or @c empty string if either the "text" attribute is not set
 /// , TextGlyph does not exits or the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getText(Layout* layout, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const std::string getText(const Layout* layout, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
 
 /// @brief Returns the text associated with this TextGlyph object.
 /// @param textGlyph a pointer to the GraphicalObject object.
 /// @return the "text" attribute of this TextGlyph object or @c empty string if either the "text" attribute is not set,
 /// or the object is not of type TextGlyph or is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getText(GraphicalObject* textGlyph);
+LIBSBMLNETWORK_EXTERN const std::string getText(const GraphicalObject* textGlyph);
 
 /// @brief Sets the value of the "text" attribute of the first TextGlyph object associated with the given id.
 /// @param Layout a pointer to the Layout object.
@@ -766,12 +766,12 @@ LIBSBMLNETWORK_EXTERN GraphicalObject* getGraphicalObject(Layout* layout, Graphi
 /// @param id the id of the model entity the TextGlyph objects associated with it to be returned.
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return @c true if this abstract GraphicalObject is of type TextGlyph, false otherwise
-LIBSBMLNETWORK_EXTERN bool isTextGlyph(Layout* layout, const std::string& id, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN bool isTextGlyph(const Layout* layout, const std::string& id, unsigned int textGlyphIndex = 0);
 
 /// @brief Predicate returning true if this abstract GraphicalObject object is of type TextGlyph.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @return @c true if this abstract GraphicalObject is of type TextGlyph, false otherwise
-LIBSBMLNETWORK_EXTERN bool isTextGlyph(GraphicalObject* graphicalObject);
+LIBSBMLNETWORK_EXTERN bool isTextGlyph(const GraphicalObject* graphicalObject);
 
 /// @brief Returns the number of additional GraphicalObject objects of the Layout object.
 /// @param Layout a pointer to the Layout object.
@@ -1113,12 +1113,12 @@ LIBSBMLNETWORK_EXTERN int setTextDimensionHeight(Layout* layout, GraphicalObject
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @return @c true if the GraphicalObject has a Curve object and the curve consists of one or more segments, false otherwise
-LIBSBMLNETWORK_EXTERN bool isSetCurve(Layout* layout, const std::string& id, unsigned int graphicalObjectIndex = 0);
+LIBSBMLNETWORK_EXTERN bool isSetCurve(const Layout* layout, const std::string& id, unsigned int graphicalObjectIndex = 0);
 
 /// @brief Predicate returning true if this GraphicalObject object has a Curve object and the curve consists of one or more segments
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @return @c true if the GraphicalObject has a Curve object and the curve consists of one or more segments, false otherwise
-LIBSBMLNETWORK_EXTERN bool isSetCurve(GraphicalObject* graphicalObject);
+LIBSBMLNETWORK_EXTERN bool isSetCurve(const GraphicalObject* graphicalObject);
 
 /// @brief Returns the Curve object of the GraphicalObject with the given index associated with the model entity with the given id of the Layout object.
 /// @param Layout a pointer to the Layout object.
@@ -1141,18 +1141,18 @@ LIBSBMLNETWORK_EXTERN int removeCurve(GraphicalObject* graphicalObject);
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @return the number of curve segments of the curve of the GraphicalObject object, or @c 0 if the object is @c NULL
 /// or does not have a curve
-LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(Layout* layout, const std::string& id, unsigned int graphicalObjectIndex = 0);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(const Layout* layout, const std::string& id, unsigned int graphicalObjectIndex = 0);
 
 /// @brief Returns the number of curve segments of the curve of this GraphicalObject object.
 /// @param graphicalObject a pointer to the GraphicalObject object.
 /// @return the number of curve segments of the curve of the GraphicalObject object, or @c 0 if the object is @c NULL
 /// or does not have a curve
-LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(GraphicalObject* graphicalObject);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(const GraphicalObject* graphicalObject);
 
 /// @brief Returns the number of curve segments of this Curve object.
 /// @param curve a pointer to the Curve object.
 /// @return the number of curve segments of the Curve object, or @c 0 if the object is @c NULL
-LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(Curve* curve);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(const Curve* curve);
 
 /// @brief Returns a pointer to the curve segment with the given index of the GraphicalObject with the given index associated with the model entity with the given id of the Layout object.
 ///// @param Layout a pointer to the Layout object.

--- a/src/libsbmlnetwork_render.h
+++ b/src/libsbmlnetwork_render.h
@@ -8839,11 +8839,6 @@ LIBSBMLNETWORK_EXTERN const double getRelativeValue(const RelAbsVector& relAbsVe
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setAbsoluteValue(RelAbsVector relAbsVector, const double& abs);
 
-/// @brief Returns the relative coordinate value of this RelAbsVector.
-/// @param relAbsVector a RelAbsVector.
-/// @return the relative coordinate value of this RelAbsVector
-LIBSBMLNETWORK_EXTERN const double getRelativeValue(const RelAbsVector& relAbsVector);
-
 /// @brief Sets the relative coordinate value of this RelAbsVector.
 /// @param relAbsVector a RelAbsVector.
 /// @param rel double value of the "rel" attribute to be set.

--- a/src/libsbmlnetwork_sbmldocument.cpp
+++ b/src/libsbmlnetwork_sbmldocument.cpp
@@ -37,21 +37,21 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE  {
         return writeSBMLToString(document);
     }
 
-    const unsigned int getSBMLLevel(SBMLDocument* document) {
+    const unsigned int getSBMLLevel(const SBMLDocument* document) {
         if (document)
             return document->getLevel();
 
         return -1;
     }
 
-    const unsigned int getSBMLVersion(SBMLDocument* document) {
+    const unsigned int getSBMLVersion(const SBMLDocument* document) {
         if (document)
             return document->getVersion();
 
         return -1;
     }
 
-    const std::string getErrorLog(SBMLDocument* document) {
+    const std::string getErrorLog(const SBMLDocument* document) {
         return error_log_getErrorLog(document);
     }
 
@@ -144,7 +144,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE  {
         return NULL;
     }
 
-    const unsigned int getNumCompartments(SBMLDocument* document) {
+    const unsigned int getNumCompartments(const SBMLDocument* document) {
         if (document && document->isSetModel())
             return document->getModel()->getNumCompartments();
 
@@ -165,7 +165,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE  {
         return NULL;
     }
 
-    const unsigned int getNumSpecies(SBMLDocument* document) {
+    const unsigned int getNumSpecies(const SBMLDocument* document) {
         if (document && document->isSetModel())
             return document->getModel()->getNumSpecies();
 
@@ -186,7 +186,7 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE  {
         return NULL;
     }
 
-    const unsigned int getNumReactions(SBMLDocument* document) {
+    const unsigned int getNumReactions(const SBMLDocument* document) {
         if (document && document->isSetModel())
             return document->getModel()->getNumReactions();
 

--- a/src/libsbmlnetwork_sbmldocument.h
+++ b/src/libsbmlnetwork_sbmldocument.h
@@ -44,17 +44,17 @@ LIBSBMLNETWORK_EXTERN const std::string writeSBML(SBMLDocument* document);
 /// @brief Returns the SBML Level of the SBMLDocument object containing this object.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the SBML Level of the SBMLDocument object containing this object.
-LIBSBMLNETWORK_EXTERN const unsigned int getSBMLLevel(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const unsigned int getSBMLLevel(const SBMLDocument* document);
 
 /// @brief Returns the Version within the SBML Level of the SBMLDocument object containing this object.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the Version within the SBML Level of the SBMLDocument object containing this object.
-LIBSBMLNETWORK_EXTERN const unsigned int getSBMLVersion(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const unsigned int getSBMLVersion(const SBMLDocument* document);
 
 /// @brief Returns the Error log containing the errors and warnings that occurred while working with the SBMLDocument object.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the Error log containing the errors and warnings that occurred while working with the SBMLDocument object.
-LIBSBMLNETWORK_EXTERN const std::string getErrorLog(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const std::string getErrorLog(const SBMLDocument* document);
 
 /// @brief Clears the Error log containing the errors and warnings that occurred while working with the SBMLDocument object.
 /// @param document a pointer to the SBMLDocument object.
@@ -116,7 +116,7 @@ SBase* getSBMLObject(SBMLDocument* document, const std::string& id);
 /// @brief Returns the number of Compartment objects in the given SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the number of Compartment objects in the given SBML document.
-LIBSBMLNETWORK_EXTERN const unsigned int getNumCompartments(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumCompartments(const SBMLDocument* document);
 
 /// @brief Returns the id of the Compartment object with the given index in the given SBML document.
 /// @param document a pointer to the SBMLDocument object.
@@ -133,7 +133,7 @@ LIBSBMLNETWORK_EXTERN Compartment* getCompartment(SBMLDocument* document, const 
 /// @brief Returns the number of Species objects in the given SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the number of Species objects in the given SBML document.
-LIBSBMLNETWORK_EXTERN const unsigned int getNumSpecies(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumSpecies(const SBMLDocument* document);
 
 /// @brief Returns the id of the Species object with the given index in the given SBML document.
 /// @param document a pointer to the SBMLDocument object.
@@ -150,7 +150,7 @@ LIBSBMLNETWORK_EXTERN Species* getSpecies(SBMLDocument* document, const std::str
 /// @brief Returns the number of Reaction objects in the given SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the number of Reaction objects in the given SBML document.
-LIBSBMLNETWORK_EXTERN const unsigned int getNumReactions(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumReactions(const SBMLDocument* document);
 
 /// @brief Returns the id of the Reaction object with the given index in the given SBML document.
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -23,8 +23,8 @@ ListOfLayouts* getListOfLayouts(SBMLDocument* document) {
     return NULL;
 }
 
-const unsigned int getNumLayouts(SBMLDocument* document) {
-    return getNumLayouts(getListOfLayouts(document));
+const unsigned int getNumLayouts(const SBMLDocument* document) {
+    return getNumLayouts(getListOfLayouts(const_cast<SBMLDocument*>(document)));
 }
 
 Layout* getLayout(SBMLDocument* document, unsigned int layoutIndex) {
@@ -775,18 +775,18 @@ bool isSetText(SBMLDocument* document, unsigned int layoutIndex, const std::stri
     return isSetText(getLayout(document, layoutIndex), id);
 }
 
-const std::string getText(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
+const std::string getText(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
     return getText(document, 0, id, graphicalObjectIndex, textGlyphIndex);
 }
 
-const std::string getText(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
-    std::string text = getText(getLayout(document, layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
+const std::string getText(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
+    std::string text = getText(getLayout(const_cast<SBMLDocument*>(document), layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
     if (!text.empty()) {
         return text;
     }
-    SBase* sBase = getSBMLObject(document, getOriginOfTextId(document, layoutIndex, id, graphicalObjectIndex, textGlyphIndex));
+    SBase* sBase = getSBMLObject(const_cast<SBMLDocument*>(document), getOriginOfTextId(document, layoutIndex, id, graphicalObjectIndex, textGlyphIndex));
     if (sBase) {
-        if (user_data_getUserData(getLayout(document, layoutIndex), "use_name_as_text_label") != "false") {
+        if (user_data_getUserData(getLayout(const_cast<SBMLDocument*>(document), layoutIndex), "use_name_as_text_label") != "false") {
             text = sBase->getName();
             if (!text.empty())
                 return text;
@@ -843,12 +843,12 @@ bool isSetOriginOfTextId(SBMLDocument* document, unsigned int layoutIndex, const
     return isSetOriginOfTextId(getLayout(document, layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
 }
 
-const std::string getOriginOfTextId(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
-    return getOriginOfTextId(getLayout(document), id, graphicalObjectIndex, textGlyphIndex);
+const std::string getOriginOfTextId(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
+    return getOriginOfTextId(getLayout(const_cast<SBMLDocument*>(document)), id, graphicalObjectIndex, textGlyphIndex);
 }
 
-const std::string getOriginOfTextId(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
-    return getOriginOfTextId(getLayout(document, layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
+const std::string getOriginOfTextId(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
+    return getOriginOfTextId(getLayout(const_cast<SBMLDocument*>(document), layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
 }
 
 int setOriginOfTextId(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const std::string& orig) {
@@ -875,12 +875,12 @@ bool isSetGraphicalObjectId(SBMLDocument* document, unsigned int layoutIndex, co
     return isSetGraphicalObjectId(getLayout(document, layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
 }
 
-const std::string getGraphicalObjectId(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
-    return getGraphicalObjectId(getLayout(document), id, graphicalObjectIndex, textGlyphIndex);
+const std::string getGraphicalObjectId(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
+    return getGraphicalObjectId(getLayout(const_cast<SBMLDocument*>(document)), id, graphicalObjectIndex, textGlyphIndex);
 }
 
-const std::string getGraphicalObjectId(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
-    return getGraphicalObjectId(getLayout(document, layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
+const std::string getGraphicalObjectId(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex, unsigned int textGlyphIndex) {
+    return getGraphicalObjectId(getLayout(const_cast<SBMLDocument*>(document), layoutIndex), id, graphicalObjectIndex, textGlyphIndex);
 }
 
 int setGraphicalObjectId(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, const std::string& graphicalObjectId) {
@@ -1425,12 +1425,12 @@ int setTextDimensionHeight(SBMLDocument* document, unsigned int layoutIndex, con
     return setTextDimensionHeight(getLayout(document, layoutIndex), getGraphicalObject(document, layoutIndex, id, graphicalObjectIndex), textGlyphIndex, height);
 }
 
-bool isSetCurve(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex) {
-    return isSetCurve(getLayout(document), id, graphicalObjectIndex);
+bool isSetCurve(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex) {
+    return isSetCurve(getLayout(const_cast<SBMLDocument*>(document)), id, graphicalObjectIndex);
 }
 
-bool isSetCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex) {
-    return isSetCurve(getLayout(document, layoutIndex), id, graphicalObjectIndex);
+bool isSetCurve(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex) {
+    return isSetCurve(getLayout(const_cast<SBMLDocument*>(document), layoutIndex), id, graphicalObjectIndex);
 }
 
 Curve* getCurve(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex) {
@@ -1441,12 +1441,12 @@ Curve* getCurve(SBMLDocument* document, unsigned int layoutIndex, const std::str
     return getCurve(getLayout(document, layoutIndex), id, graphicalObjectIndex);
 }
 
-const unsigned int getNumCurveSegments(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex) {
-    return getNumCurveSegments(getLayout(document), id, graphicalObjectIndex);
+const unsigned int getNumCurveSegments(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex) {
+    return getNumCurveSegments(getLayout(const_cast<SBMLDocument*>(document)), id, graphicalObjectIndex);
 }
 
-const unsigned int getNumCurveSegments(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex) {
-    return getNumCurveSegments(getLayout(document, layoutIndex), id, graphicalObjectIndex);
+const unsigned int getNumCurveSegments(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex) {
+    return getNumCurveSegments(getLayout(const_cast<SBMLDocument*>(document), layoutIndex), id, graphicalObjectIndex);
 }
 
 LineSegment* getCurveSegment(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex, unsigned int curveSegmentIndex) {

--- a/src/libsbmlnetwork_sbmldocument_layout.h
+++ b/src/libsbmlnetwork_sbmldocument_layout.h
@@ -20,7 +20,7 @@ LIBSBMLNETWORK_EXTERN ListOfLayouts* getListOfLayouts(SBMLDocument* document);
 /// @brief Returns the number of items in the ListOfLayouts of this SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the number of items in of this SBML document, or @c 0 if the object is @c NULL
-LIBSBMLNETWORK_EXTERN const unsigned int getNumLayouts(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumLayouts(const SBMLDocument* document);
 
 /// @brief Returns a pointer to the Layout with the given index in the ListOfLayouts of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
@@ -1540,7 +1540,7 @@ LIBSBMLNETWORK_EXTERN bool isSetText(SBMLDocument* document, unsigned int layout
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return the "text" attribute of this TextGlyph object or @c empty string if either the "text" attribute is not set
 /// , TextGlyph does not exits or the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getText(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const std::string getText(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
 
 /// @brief Returns the "text" attribute of the TextGlyph object with the given index associated with the given id in
 /// the Layout object with the given index of the SBML document.
@@ -1551,7 +1551,7 @@ LIBSBMLNETWORK_EXTERN const std::string getText(SBMLDocument* document, const st
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return the "text" attribute of this TextGlyph object or @c empty string if either the "text" attribute is not set
 /// , TextGlyph does not exits or the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getText(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const std::string getText(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
 
 /// @brief Sets the value of the "text" attribute of the first TextGlyph object associated with the given id in
 /// the first Layout object of the SBML document.
@@ -1656,7 +1656,7 @@ LIBSBMLNETWORK_EXTERN bool isSetOriginOfTextId(SBMLDocument* document, unsigned 
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return the id of the origin of text of this TextGlyph object or @c empty string if either the "originOfTextId" attribute is not set
 /// , TextGlyph does not exits or the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getOriginOfTextId(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const std::string getOriginOfTextId(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
 
 /// @brief Returns the id of the origin of text of the TextGlyph object with the given index associated with the given id in
 /// the Layout object with the given index of the SBML document.
@@ -1667,7 +1667,7 @@ LIBSBMLNETWORK_EXTERN const std::string getOriginOfTextId(SBMLDocument* document
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return the id of the origin of text of this TextGlyph object or @c empty string if either the "originOfTextId" attribute is not set
 /// , TextGlyph does not exits or the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getOriginOfTextId(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const std::string getOriginOfTextId(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
 
 /// @brief Sets id of the origin of text of the first TextGlyph object with the given index associated with the given id in
 /// the first Layout object of the SBML document.
@@ -1738,7 +1738,7 @@ LIBSBMLNETWORK_EXTERN bool isSetGraphicalObjectId(SBMLDocument* document, unsign
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return the id of associated graphical object of this TextGlyph or @c empty string if either the "graphicalObjectId" attribute is not set
 /// , TextGlyph does not exits or the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getGraphicalObjectId(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const std::string getGraphicalObjectId(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
 
 /// @brief Returns the id of the associated graphical object of the TextGlyph object with the given index associated with the given id
 /// in the Layout object with the given index of the SBML document.
@@ -1749,7 +1749,7 @@ LIBSBMLNETWORK_EXTERN const std::string getGraphicalObjectId(SBMLDocument* docum
 /// @param textGlyphIndex the index of the TextGlyph to return.
 /// @return the id of associated graphical object of this TextGlyph or @c empty string if either the "graphicalObjectId" attribute is not set
 /// , TextGlyph does not exits or the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getGraphicalObjectId(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const std::string getGraphicalObjectId(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0, unsigned int textGlyphIndex = 0);
 
 /// @brief Sets the id of the associated graphical object of the first TextGlyph object associated with the given id in
 /// the first Layout object of the SBML document.
@@ -2565,7 +2565,7 @@ LIBSBMLNETWORK_EXTERN int setTextDimensionHeight(SBMLDocument* document, unsigne
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @return @c true if the GraphicalObject has a Curve object and the curve consists of one or more segments, false otherwise
-LIBSBMLNETWORK_EXTERN bool isSetCurve(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0);
+LIBSBMLNETWORK_EXTERN bool isSetCurve(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0);
 
 /// @brief Predicate returning true if the GraphicalObject with the given index associated with the model entity with the given id of the Layout object with the given index in the SBML document
 /// has a Curve object and the curve consists of one or more segments.
@@ -2574,7 +2574,7 @@ LIBSBMLNETWORK_EXTERN bool isSetCurve(SBMLDocument* document, const std::string&
 /// @param id the id of the model entity the GraphicalObject object associated with it to be returned.
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @return @c true if the GraphicalObject has a Curve object and the curve consists of one or more segments, false otherwise
-LIBSBMLNETWORK_EXTERN bool isSetCurve(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0);
+LIBSBMLNETWORK_EXTERN bool isSetCurve(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0);
 
 /// @brief Returns the Curve object of the GraphicalObject with the given index associated with the model entity with the given id of the first Layout object in the SBML document.
 /// @param document a pointer to the SBMLDocument object.
@@ -2597,7 +2597,7 @@ LIBSBMLNETWORK_EXTERN Curve* getCurve(SBMLDocument* document, unsigned int layou
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @return the number of curve segments of the curve of the GraphicalObject object, or @c 0 if the object is @c NULL
 /// or does not have a curve
-LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(const SBMLDocument* document, const std::string& id, unsigned int graphicalObjectIndex = 0);
 
 /// @brief Returns the number of curve segments of the curve of the GraphicalObject with the given index associated with the model entity with the given id of the Layout object with the given index in the SBML document.
 /// @param document a pointer to the SBMLDocument object.
@@ -2606,7 +2606,7 @@ LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(SBMLDocument* docum
 /// @param graphicalObjectIndex the index of the GraphicalObject to return.
 /// @return the number of curve segments of the curve of the GraphicalObject object, or @c 0 if the object is @c NULL
 /// or does not have a curve
-LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumCurveSegments(const SBMLDocument* document, unsigned int layoutIndex, const std::string& id, unsigned int graphicalObjectIndex = 0);
 
 /// @brief Returns a pointer to the curve segment with the given index of the GraphicalObject with the given index associated with the model entity with the given id of the first Layout object in the SBML document.
 /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -4239,8 +4239,8 @@ int setStrokeColor(SBMLDocument* document, const std::string& attribute, const s
     return -1;
 }
 
-const std::string getCompartmentStrokeColor(SBMLDocument* document) {
-    return getCompartmentStrokeColor(getGlobalRenderInformation(document));
+const std::string getCompartmentStrokeColor(const SBMLDocument* document) {
+    return getCompartmentStrokeColor(getGlobalRenderInformation(const_cast<SBMLDocument*>(document)));
 }
 
 int setCompartmentStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& stroke) {
@@ -4251,8 +4251,8 @@ int setCompartmentStrokeColor(SBMLDocument* document, unsigned int layoutIndex, 
     return -1;
 }
 
-const std::string getSpeciesStrokeColor(SBMLDocument* document) {
-    return getSpeciesStrokeColor(getGlobalRenderInformation(document));
+const std::string getSpeciesStrokeColor(const SBMLDocument* document) {
+    return getSpeciesStrokeColor(getGlobalRenderInformation(const_cast<SBMLDocument*>(document)));
 }
 
 int setSpeciesStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& stroke) {
@@ -4263,8 +4263,8 @@ int setSpeciesStrokeColor(SBMLDocument* document, unsigned int layoutIndex, cons
     return -1;
 }
 
-const std::string getReactionStrokeColor(SBMLDocument* document) {
-    return getReactionStrokeColor(getGlobalRenderInformation(document));
+const std::string getReactionStrokeColor(const SBMLDocument* document) {
+    return getReactionStrokeColor(getGlobalRenderInformation(const_cast<SBMLDocument*>(document)));
 }
 
 int setReactionStrokeColor(SBMLDocument* document, unsigned int layoutIndex, const std::string& stroke, bool setSpeciesReferenceGlyphs) {
@@ -4389,8 +4389,8 @@ int setStrokeWidth(SBMLDocument* document, const std::string& attribute, const d
     return -1;
 }
 
-const double getCompartmentStrokeWidth(SBMLDocument* document) {
-    return getCompartmentStrokeWidth(getGlobalRenderInformation(document));
+const double getCompartmentStrokeWidth(const SBMLDocument* document) {
+    return getCompartmentStrokeWidth(getGlobalRenderInformation(const_cast<SBMLDocument*>(document)));
 }
 
 int setCompartmentStrokeWidth(SBMLDocument* document, unsigned int layoutIndex, const double& strokeWidth) {

--- a/src/libsbmlnetwork_sbmldocument_render.cpp
+++ b/src/libsbmlnetwork_sbmldocument_render.cpp
@@ -25,8 +25,8 @@ ListOfGlobalRenderInformation* getListOfGlobalRenderInformation(SBMLDocument* do
     return NULL;
 }
 
-const unsigned int getNumGlobalRenderInformation(SBMLDocument* document) {
-    return getNumGlobalRenderInformation(getListOfGlobalRenderInformation(document));
+const unsigned int getNumGlobalRenderInformation(const SBMLDocument* document) {
+    return getNumGlobalRenderInformation(getListOfGlobalRenderInformation(const_cast<SBMLDocument*>(document)));
 }
 
 GlobalRenderInformation* getGlobalRenderInformation(SBMLDocument* document, unsigned int renderIndex) {

--- a/src/libsbmlnetwork_sbmldocument_render.h
+++ b/src/libsbmlnetwork_sbmldocument_render.h
@@ -21,7 +21,7 @@ LIBSBMLNETWORK_EXTERN ListOfGlobalRenderInformation* getListOfGlobalRenderInform
 /// @brief Returns the number of items in the ListOfGlobalRenderInformation of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the number of items in the ListOfGlobalRenderInformation of the SBML document, or @c 0 if the object is @c NULL
-LIBSBMLNETWORK_EXTERN const unsigned int getNumGlobalRenderInformation(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const unsigned int getNumGlobalRenderInformation(const SBMLDocument* document);
 
 /// @brief Returns a pointer to the GlobalRenderInformation with the given index in the ListOfGlobalRenderInformation of the SBML document.
 /// @param renderIndex the index number of the GlobalRenderInformation to return.
@@ -7173,7 +7173,7 @@ LIBSBMLNETWORK_EXTERN int setStrokeColor(SBMLDocument* document, const std::stri
 /// @brief Returns the value of the "stroke" attribute of the RenderGroup of the Style for the Compartment.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the "stroke" attribute of the RenderGroup of the Style for the Compartment, or @c "" if the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getCompartmentStrokeColor(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const std::string getCompartmentStrokeColor(const SBMLDocument* document);
 
 /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the Style for all CompartmentGlyph objects.
 /// @param document a pointer to the SBMLDocument object.
@@ -7185,7 +7185,7 @@ LIBSBMLNETWORK_EXTERN int setCompartmentStrokeColor(SBMLDocument* document, unsi
 /// @brief Returns the value of the "stroke" attribute of the RenderGroup of the Style for the Species.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the "stroke" attribute of the RenderGroup of the Style for the Species, or @c "" if the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getSpeciesStrokeColor(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const std::string getSpeciesStrokeColor(const SBMLDocument* document);
 
 /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the Style for all SpeciesGlyph objects.
 /// @param document a pointer to the SBMLDocument object.
@@ -7197,7 +7197,7 @@ LIBSBMLNETWORK_EXTERN int setSpeciesStrokeColor(SBMLDocument* document, unsigned
 /// @brief Returns the value of the "stroke" attribute of the RenderGroup of the Style for the Reaction.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the "stroke" attribute of the RenderGroup of the Style for the Reaction, or @c "" if the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const std::string getReactionStrokeColor(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const std::string getReactionStrokeColor(const SBMLDocument* document);
 
 /// @brief Sets the value of the "stroke" attribute of the RenderGroup of the Style for all ReactionGlyph objects and their SpeciesReferenceGlyph objects.
 /// @param document a pointer to the SBMLDocument object.
@@ -7270,7 +7270,7 @@ LIBSBMLNETWORK_EXTERN int setStrokeWidth(SBMLDocument* document, const std::stri
 /// @brief Returns the value of the "stroke-width" attribute of the RenderGroup of the Style for the Compartment.
 /// @param document a pointer to the SBMLDocument object.
 /// @return the "stroke-width" attribute of the RenderGroup of the Style for the Compartment, or @c 0.0 if the object is @c NULL.
-LIBSBMLNETWORK_EXTERN const double getCompartmentStrokeWidth(SBMLDocument* document);
+LIBSBMLNETWORK_EXTERN const double getCompartmentStrokeWidth(const SBMLDocument* document);
 
 /// @brief Sets the value of the "stroke-width" attribute of the RenderGroup of the Style for all CompartmentGlyph objects.
 /// @param document a pointer to the SBMLDocument object.


### PR DESCRIPTION
Needed a couple particular functions for Antimony, so implemented support for those and several others.  Many many other possible functions could be similarly updated, but it's very late in the process to suddenly realize that 'gets' only need const input, so this is probably fine for now.