### PR TITLE
add-features-fix-bugs-reported-by-lucian

### DIFF
--- a/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
+++ b/src/bindings/python/ctypes/libsbmlnetwork.py.cmake
@@ -1094,6 +1094,31 @@ class LibSBMLNetwork:
         """
         return lib.c_api_getSpeciesGlyphIndex(self.sbml_object, str(species_id).encode(), str(reaction_id).encode(), reaction_glyph_index, layout_index)
 
+    def getConnectedReactionsFor(self, species_id, species_glyph_index = 0, layout_index=0):
+        """
+        Returns the ids of connected reactions for the given species_id and species_glyph_index in the Layout object with the given index in the given SBMLDocument
+
+        :Parameters:
+
+            - species_id (string): a string that determines the id of the Species
+            - species_glyph_index (int): an integer that determines the index of the SpeciesGlyph
+            - reaction_id (string): a string that determines the id of the Reaction
+            - layout_index (int, optional): an integer (default: 0) that determines the index of the Layout object in the given SBMLDocument
+
+        :Returns:
+
+            a list of connnected reactions for the given species_id and species_glyph_index in the Layout object with the given index in the given SBMLDocument
+
+        """
+        lib.c_api_getConnectedReactionsFor.restype = ctypes.c_char_p
+        list_of_connected_reactions = []
+        for n in range(lib.c_api_getNumConnectedReactionsFor(self.sbml_object, str(species_id).encode(), species_glyph_index, layout_index)):
+            list_of_connected_reactions.append(ctypes.c_char_p(lib.c_api_getConnectedReactionsFor(self.sbml_object, str(species_id).encode(), species_glyph_index, n, layout_index)).value.decode())
+
+        return list_of_connected_reactions
+
+
+
     def isSpeciesGlyph(self, species_id, layout_index=0):
         """
         Returns whether the given species_id is associated with a SpeciesGlyph in the Layout object with the given index in the given SBMLDocument

--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -327,6 +327,18 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return getSpeciesGlyphIndex(document, layoutIndex, speciesId, reactionId, reactionGlyphIndex);
     }
 
+    const int c_api_getNumConnectedReactionsFor(SBMLDocument* document, const char* speciesId, int speciesGlyphIndex, int layoutIndex) {
+        return getConnectedReactionsFor(document, layoutIndex, speciesId, speciesGlyphIndex).size();
+    }
+
+    const char* c_api_getConnectedReactionsFor(SBMLDocument* document, const char* speciesId, int speciesGlyphIndex, int index, int layoutIndex) {
+        std::vector<std::string> connectedReactions = getConnectedReactionsFor(document, layoutIndex, speciesId, speciesGlyphIndex);
+        if (index < connectedReactions.size())
+            return strdup(connectedReactions[index].c_str());
+
+        return "";
+    }
+
     bool c_api_isSpeciesGlyph(SBMLDocument* document, const char* speciesId, int layoutIndex) {
         return isSpeciesGlyph(document, layoutIndex, speciesId);
     }

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -481,6 +481,23 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @return the index of the SpeciesGlyph object among the list of SpeciesGlyph objects associated with the given species id that is associated with the given reaction id,
     LIBSBMLNETWORK_EXTERN const int c_api_getSpeciesGlyphIndex(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex = 0, int layoutIndex = 0);
 
+    /// @brief Returns the number of connected reactions for the SpeciesGlyph with the given species id and index in the Layout object with the given index in the ListOfLayouts of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param speciesId the id of the species the number of connected reactions is going to be returned.
+    /// @param speciesGlyphIndex the index of the SpeciesGlyph object.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return the number of connected reactions for the SpeciesGlyph with the given species id and index in the Layout object,
+    LIBSBMLNETWORK_EXTERN const int c_api_getNumConnectedReactionsFor(SBMLDocument* document, const char* speciesId, int speciesGlyphIndex = 0, int layoutIndex = 0);
+
+    /// @brief Returns the id of the connected reaction for the SpeciesGlyph with the given species id and index in the Layout object with the given index in the ListOfLayouts of the SBML document.
+    /// @param document a pointer to the SBMLDocument object.
+    /// @param speciesId the id of the species the id of the connected reaction is going to be returned.
+    /// @param speciesGlyphIndex the index of the SpeciesGlyph object.
+    /// @param index the index of the connected reaction.
+    /// @param layoutIndex the index number of the Layout to return.
+    /// @return the id of the connected reaction for the SpeciesGlyph with the given species id and index in the Layout object,
+    LIBSBMLNETWORK_EXTERN const char* c_api_getConnectedReactionsFor(SBMLDocument* document, const char* speciesId, int speciesGlyphIndex = 0, int index = 0, int layoutIndex = 0);
+
     /// @brief Predicate returning true if the abstract GraphicalObject with the given id in the Layout object with the given index of the SBML document is of type SpeciesGlyph.
     /// @param document a pointer to the SBMLDocument object.
     /// @param layoutIndex the index number of the Layout to return.

--- a/src/libsbmlnetwork_layout.cpp
+++ b/src/libsbmlnetwork_layout.cpp
@@ -289,7 +289,7 @@ SpeciesGlyph* getSpeciesGlyph(Layout* layout, const unsigned int speciesGlyphInd
     return NULL;
 }
 
-const int getSpeciesGlyphIndex(Layout* layout, const char* speciesId, const char* reactionId, unsigned  int reactionGlyphIndex) {
+const int getSpeciesGlyphIndex(Layout* layout, const std::string& speciesId, const std::string& reactionId, unsigned  int reactionGlyphIndex) {
     return getIndexOfConnectedSpeciesGlyph(getSpeciesReferenceGlyphs(getReactionGlyph(layout, reactionId, reactionGlyphIndex)), getSpeciesGlyphs(layout, speciesId));
 }
 
@@ -302,6 +302,27 @@ const std::string getSpeciesId(GraphicalObject* speciesGlyph) {
         return ((SpeciesGlyph*)speciesGlyph)->getSpeciesId();
 
     return "";
+}
+
+std::vector<std::string> getConnectedReactionsFor(Layout* layout, const std::string& speciesId, int speciesGlyphIndex) {
+    std::vector<std::string> connectedReactions;
+    if (layout) {
+        SpeciesGlyph* speciesGlyph = getSpeciesGlyph(layout, speciesId, speciesGlyphIndex);
+        if (speciesGlyph) {
+            for (unsigned int i = 0; i < layout->getNumReactionGlyphs(); i++) {
+                for (unsigned int j = 0; j < layout->getReactionGlyph(i)->getNumSpeciesReferenceGlyphs(); j++) {
+                    SpeciesReferenceGlyph* speciesReferenceGlyph = layout->getReactionGlyph(i)->getSpeciesReferenceGlyph(j);
+                    if (speciesReferenceGlyph->getSpeciesGlyphId() == speciesGlyph->getId()) {
+                        std::string reactionId = layout->getReactionGlyph(i)->getReactionId();
+                        if (std::find(connectedReactions.begin(), connectedReactions.end(), reactionId) == connectedReactions.end())
+                            connectedReactions.push_back(reactionId);
+                    }
+                }
+            }
+        }
+    }
+
+    return connectedReactions;
 }
 
 bool isSpeciesGlyph(Layout* layout, const std::string& id, const unsigned int speciesGlyphIndex) {

--- a/src/libsbmlnetwork_layout.h
+++ b/src/libsbmlnetwork_layout.h
@@ -240,7 +240,7 @@ LIBSBMLNETWORK_EXTERN SpeciesGlyph* getSpeciesGlyph(Layout* layout, const unsign
 /// @param reactionId the id of the reaction the the SpeciesGlyph objects of which to be returned.
 /// @param reactionGlyphIndex the index of the ReactionGlyph.
 /// @return the index of the SpeciesGlyph object associated in the list of SpeciesGlyph objects among the list of SpeciesGlyph objects associated with the given species id that is associated with the given reaction id, or @c 0 if the object is @c NULL
-LIBSBMLNETWORK_EXTERN const int getSpeciesGlyphIndex(Layout* layout, const char* speciesId, const char* reactionId, unsigned int reactionGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const int getSpeciesGlyphIndex(Layout* layout, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex = 0);
 
 /// Returns the id of the species associated with the SpeciesGlyph object with the given id of the Layout object.
 /// @param Layout a pointer to the Layout object.
@@ -254,6 +254,13 @@ LIBSBMLNETWORK_EXTERN const std::string getSpeciesId(Layout* layout, const std::
 /// @param speciesGlyph a pointer to the GraphicalObject object.
 /// @return the value of the "species" attribute, or @c "" if the object is not of type SpeciesGlyph or is @c NULL
 LIBSBMLNETWORK_EXTERN const std::string getSpeciesId(GraphicalObject* speciesGlyph);
+
+/// @brief Returns a vector of the ids of the Reactions which are connected to the SpeciesGlyph with the given id and index
+/// @param Layout a pointer to the Layout object.
+/// @param speciesId the id of the Species.
+/// @param speciesGlyphIndex the index of the SpeciesGlyph.
+/// @return a vector of the ids of the Reactions which are connected to the SpeciesGlyph with the given id and index.
+LIBSBMLNETWORK_EXTERN std::vector<std::string> getConnectedReactionsFor(Layout* layout, const std::string& speciesId, int speciesGlyphIndex = 0);
 
 /// @brief Predicate returning true if the abstract GraphicalObject with the given id of the Layout object is of type SpeciesGlyph.
 /// @param Layout a pointer to the Layout object.

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -346,12 +346,16 @@ SpeciesGlyph* getSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, 
     return getSpeciesGlyph(getLayout(document, layoutIndex), speciesGlyphIndex);
 }
 
-const int getSpeciesGlyphIndex(SBMLDocument* document, const char* speciesId, const char* reactionId, unsigned int reactionGlyphIndex) {
+const int getSpeciesGlyphIndex(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex) {
     return getSpeciesGlyphIndex(getLayout(document), speciesId, reactionId, reactionGlyphIndex);
 }
 
-const int getSpeciesGlyphIndex(SBMLDocument* document, unsigned int layoutIndex, const char* speciesId, const char* reactionId, unsigned int reactionGlyphIndex) {
+const int getSpeciesGlyphIndex(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex) {
     return getSpeciesGlyphIndex(getLayout(document, layoutIndex), speciesId, reactionId, reactionGlyphIndex);
+}
+
+std::vector<std::string> getConnectedReactionsFor(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, int speciesGlyphIndex) {
+    return getConnectedReactionsFor(getLayout(document, layoutIndex), speciesId, speciesGlyphIndex);
 }
 
 bool isSpeciesGlyph(SBMLDocument* document, const std::string& id) {

--- a/src/libsbmlnetwork_sbmldocument_layout.h
+++ b/src/libsbmlnetwork_sbmldocument_layout.h
@@ -498,7 +498,7 @@ LIBSBMLNETWORK_EXTERN  SpeciesGlyph* getSpeciesGlyph(SBMLDocument* document, uns
 /// @param reactionGlyphIndex the index number of the ReactionGlyph object to return.
 /// @return the index of the SpeciesGlyph object associated with the entered species id among the list of SpeciesGlyph objects associated with the entered reaction id,
 /// or @c -1 if the object is @c NULL or has no associated SpeciesGlyph objects
-LIBSBMLNETWORK_EXTERN const int getSpeciesGlyphIndex(SBMLDocument* document, const char* speciesId, const char* reactionId, unsigned int reactionGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const int getSpeciesGlyphIndex(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex = 0);
 
 /// @brief Returns the index of the SpeciesGlyph object associated in the list of SpeciesGlyph objects among the list of SpeciesGlyph objects associated with the given species id that is associated with the given reaction id with the given index in the Layout object with the given index in the ListOfLayouts of the SBML document.
 /// @param document a pointer to the SBMLDocument object.
@@ -508,7 +508,15 @@ LIBSBMLNETWORK_EXTERN const int getSpeciesGlyphIndex(SBMLDocument* document, con
 /// @param reactionGlyphIndex the index number of the ReactionGlyph object to return.
 /// @return the index of the SpeciesGlyph object associated with the entered species id among the list of SpeciesGlyph objects associated with the entered reaction id,
 /// or @c -1 if the object is @c NULL or has no associated SpeciesGlyph objects
-LIBSBMLNETWORK_EXTERN const int getSpeciesGlyphIndex(SBMLDocument* document, unsigned int layoutIndex, const char* speciesId, const char* reactionId, unsigned int reactionGlyphIndex = 0);
+LIBSBMLNETWORK_EXTERN const int getSpeciesGlyphIndex(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex = 0);
+
+/// @brief Returns a vector of the ids of the Reactions which are connected to the SpeciesGlyph with the given id and index in the Layout object with the given index of the SBML document.
+/// @param document a pointer to the SBMLDocument object.
+/// @param layoutIndex the index number of the Layout to return.
+/// @param speciesId the id of the Species.
+/// @param speciesGlyphIndex the index of the SpeciesGlyph.
+/// @return a vector of the ids of the Reactions which are connected to the SpeciesGlyph with the given id and index.
+LIBSBMLNETWORK_EXTERN std::vector<std::string> getConnectedReactionsFor(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, int speciesGlyphIndex = 0);
 
 /// @brief Predicate returning true if the abstract GraphicalObject with the given id in the first Layout object of the SBML document is of type SpeciesGlyph.
 /// @param document a pointer to the SBMLDocument object.


### PR DESCRIPTION
add 'getConnectedReactionsFor', which is the function to get the reactions connected to a species glyph.
