### PR TITLE
setDimensionHeight/Width was not always 'sticky', nor consistent.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
         libroadrunner_deps_owner: [ "sys-bio" ]
         libroadrunner_deps_repo: [ "libroadrunner-deps" ]
         libroadrunner_deps_name: [ "libroadrunner-deps" ]
-        libroadrunner_deps_release_version: [ "v2.2.13" ]
+        libroadrunner_deps_release_version: [ "v2.2.15" ]
         python_version: [ "3.11" ]
     runs-on: ${{ matrix.platform.os_name }}
     container:

--- a/src/libsbmlnetwork_layout.cpp
+++ b/src/libsbmlnetwork_layout.cpp
@@ -1056,21 +1056,18 @@ int setDimensionWidth(Layout* layout, const std::string& id, unsigned int graphi
 
 int setDimensionWidth(Layout* layout, GraphicalObject* graphicalObject, const double& width) {
     double changedWidth = width - getDimensionWidth(graphicalObject);
-    if ((isReactionGlyph(graphicalObject) && !setDimensionWidth(layout, (ReactionGlyph*)graphicalObject, width)) || !setDimensionWidth(getBoundingBox(graphicalObject), width)) {
+    if (isReactionGlyph(graphicalObject)) {
+        if (isSetCurve(graphicalObject))
+            if (setDimensionWidth(getCurve(graphicalObject), width))
+                return -1;
+    }
+    if (!setDimensionWidth(getBoundingBox(graphicalObject), width)) {
         fix_elements_fixGraphicalObjectWidth(graphicalObject);
         updateAssociatedTextGlyphsDimensionWidth(layout, graphicalObject, changedWidth);
         return 0;
     }
 
     return -1;
-}
-
-int setDimensionWidth(Layout* layout, ReactionGlyph* reactionGlyph, const double& x) {
-    if (isSetCurve(reactionGlyph))
-        if (setDimensionWidth(getCurve(reactionGlyph), x))
-            return -1;
-
-    return setDimensionWidth(getBoundingBox(reactionGlyph), x);
 }
 
 int setDimensionWidth(BoundingBox* boundingBox, const double& width) {
@@ -1143,21 +1140,18 @@ int setDimensionHeight(Layout* layout, const std::string& id, unsigned int graph
 
 int setDimensionHeight(Layout* layout, GraphicalObject* graphicalObject, const double& height) {
     double changedHeight = height - getDimensionHeight(graphicalObject);
-    if ((isReactionGlyph(graphicalObject) && !setDimensionHeight(layout, (ReactionGlyph*)graphicalObject, height)) || !setDimensionHeight(getBoundingBox(graphicalObject), height)) {
+    if (isReactionGlyph(graphicalObject)) {
+        if (isSetCurve(graphicalObject))
+            if (setDimensionHeight(getCurve(graphicalObject), height))
+                return -1;
+    }
+    if (!setDimensionHeight(getBoundingBox(graphicalObject), height)) {
         fix_elements_fixGraphicalObjectHeight(graphicalObject);
         updateAssociatedTextGlyphsDimensionHeight(layout, graphicalObject, changedHeight);
         return 0;
     }
 
     return -1;
-}
-
-int setDimensionHeight(Layout* layout, ReactionGlyph* reactionGlyph, const double& x) {
-    if (isSetCurve(reactionGlyph))
-        if (setDimensionHeight(getCurve(reactionGlyph), x))
-            return -1;
-
-    return setDimensionHeight(getBoundingBox(reactionGlyph), x);
 }
 
 int setDimensionHeight(BoundingBox* boundingBox, const double& height) {

--- a/src/libsbmlnetwork_layout.h
+++ b/src/libsbmlnetwork_layout.h
@@ -1044,13 +1044,6 @@ LIBSBMLNETWORK_EXTERN int setDimensionWidth(Layout* layout, const std::string& i
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setDimensionWidth(Layout* layout, GraphicalObject* graphicalObject, const double& width);
 
-/// @brief Sets the value of the "width" attribute of the bounding box this ReactionGlyph object.
-/// @param layout a pointer to the Layout object.
-/// @param reactionGlyph a pointer to the ReactionGlyph object.
-/// @param width a double value to use as the value of the "width" attribute of the bounding box of this ReactionGlyph object.
-/// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionWidth(Layout* layout, ReactionGlyph* reactionGlyph, const double& width);
-
 /// @brief Sets the value of the "width" attribute of this BoundingBox object.
 /// @param boundingBox a pointer to the BoundingBox object.
 /// @param width a double value to use as the value of the "width" attribute of this BoundingBox object.
@@ -1103,13 +1096,6 @@ LIBSBMLNETWORK_EXTERN int setDimensionHeight(Layout* layout, const std::string& 
 /// @param width a double value to use as the value of the "height" attribute of this GraphicalObject object.
 /// @return integer value indicating success/failure of the function.
 LIBSBMLNETWORK_EXTERN int setDimensionHeight(Layout* layout, GraphicalObject* graphicalObject, const double& height);
-
-/// @brief Sets the value of the "height" attribute of the bounding box of this ReactionGlyph object associated with the object with the given id of the Layout object.
-/// @param layout a pointer to the Layout object.
-/// @param reactionGlyph a pointer to the ReactionGlyph object.
-/// @param height a double value to use as the value of the "height" attribute of the bounding box of this ReactionGlyph object.
-/// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int setDimensionHeight(Layout* layout, ReactionGlyph* reactionGlyph, const double& height);
 
 /// @brief Sets the value of the "height" attribute of this BoundingBox object.
 /// @param layout a pointer to the Layout object.

--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -1572,14 +1572,14 @@ unsigned int getStrokeDash(RenderGroup* renderGroup, unsigned int strokeDashInde
     if (isRenderGroup(renderGroup))
         return renderGroup->getDashByIndex(strokeDashIndex);
 
-    return NAN;
+    return 0;
 }
 
 unsigned int getStrokeDash(Transformation2D* transformation2D, unsigned int strokeDashIndex) {
     if (isGraphicalPrimitive1D(transformation2D))
         ((GraphicalPrimitive1D*)transformation2D)->getDashByIndex(strokeDashIndex);
 
-    return NAN;
+    return 0;
 }
 
 int setStrokeDash(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int dash) {


### PR DESCRIPTION
Now it is!

Depending on whether you called setDimensionWidth or setReactionDimensionWidth, different functions would get called.  This synchronizes everything through a single function instead of two.

The specific bug this fixes was that calling setReactionDimensionWidth didn't persist across calling autoLayout, but calling setDimensionWidth on an individual reaction did.  Now both persist.