### PR TITLE
Return 0 for getNumGeometricShapes(null), instead of 4.3 billion.

### DIFF
--- a/src/libsbmlnetwork_render.cpp
+++ b/src/libsbmlnetwork_render.cpp
@@ -3495,7 +3495,7 @@ unsigned int getNumGeometricShapes(RenderGroup* renderGroup) {
     if (renderGroup)
         return renderGroup->getNumElements();
 
-    return -1;
+    return 0;
 }
 
 Transformation2D* getGeometricShape(RenderInformationBase* renderInformationBase, GraphicalObject* graphicalObject, unsigned int geometricShapeIndex) {


### PR DESCRIPTION
(OK, technically it was returning -1, but it was an unsigned int, hence 4.3 billion.)