### PR TITLE
Allow the create Alias node functions to not re-run autolayout.

### DIFF
--- a/src/c_api/libsbmlnetwork_c_api.cpp
+++ b/src/c_api/libsbmlnetwork_c_api.cpp
@@ -207,8 +207,8 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
         return setUseNameAsTextLabel(document, layoutIndex, useNameAsTextLabels);
     }
 
-    int c_api_createAliasSpeciesGlyph(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex, int layoutIndex) {
-        return createAliasSpeciesGlyph(document, layoutIndex, speciesId, reactionId, reactionGlyphIndex);
+    int c_api_createAliasSpeciesGlyph(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex, int layoutIndex, int updateCurves) {
+        return createAliasSpeciesGlyph(document, layoutIndex, speciesId, reactionId, reactionGlyphIndex, updateCurves);
     }
 
     int c_api_createAliasReactionGlyph(SBMLDocument* document, const char* reactionId, int layoutIndex) {

--- a/src/c_api/libsbmlnetwork_c_api.h
+++ b/src/c_api/libsbmlnetwork_c_api.h
@@ -267,8 +267,9 @@ namespace LIBSBMLNETWORK_CPP_NAMESPACE {
     /// @param reactionId the id of the reaction to create an alias SpeciesGlyph for.
     /// @param reactionGlyphIndex the index of the ReactionGlyph object.
     /// @param layoutIndex the index number of the Layout to return.
+    /// @param updateCurves whether to re-run auto-layout after adding the glyph.
     /// @return integer value indicating success/failure of the function.
-    LIBSBMLNETWORK_EXTERN int c_api_createAliasSpeciesGlyph(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex, int layoutIndex);
+    LIBSBMLNETWORK_EXTERN int c_api_createAliasSpeciesGlyph(SBMLDocument* document, const char* speciesId, const char* reactionId, int reactionGlyphIndex, int layoutIndex, int updateCurves);
 
     /// @brief Create an alias ReactionGlyph object for Reaction with the given id
     /// @param document a pointer to the SBMLDocument object.

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -104,17 +104,24 @@ int createDefaultLayoutLocations(SBMLDocument* document, const int maxNumConnect
     return setDefaultLayoutLocations(document, layout, maxNumConnectedEdges, resetFixedPositionElements, fixedPositionNodesSet);
 }
 
-int createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex) {
-    if (!alias_element_createAliasSpeciesGlyph(getLayout(document), speciesId, getReactionGlyph(document, reactionId, reactionGlyphIndex)))
-        return updateLayoutCurves(document, getLayout(document));
+int createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex, bool updateCurves) {
+    if (!alias_element_createAliasSpeciesGlyph(getLayout(document), speciesId, getReactionGlyph(document, reactionId, reactionGlyphIndex))) {
+        if (updateCurves) {
+            return updateLayoutCurves(document, getLayout(document));
+        }
+        return 0;
+    }
 
     return -1;
 }
 
-int createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex) {
-    if (!alias_element_createAliasSpeciesGlyph(getLayout(document, layoutIndex), speciesId, getReactionGlyph(document, layoutIndex, reactionId, reactionGlyphIndex)))
-        return updateLayoutCurves(document, getLayout(document, layoutIndex));
-
+int createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex, bool updateCurves) {
+    if (!alias_element_createAliasSpeciesGlyph(getLayout(document, layoutIndex), speciesId, getReactionGlyph(document, layoutIndex, reactionId, reactionGlyphIndex)), updateCurves) {
+        if (updateCurves) {
+            return updateLayoutCurves(document, getLayout(document, layoutIndex));
+        }
+        return 0;
+    }
     return -1;
 }
 

--- a/src/libsbmlnetwork_sbmldocument_layout.cpp
+++ b/src/libsbmlnetwork_sbmldocument_layout.cpp
@@ -116,12 +116,14 @@ int createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId
 }
 
 int createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex, bool updateCurves) {
-    if (!alias_element_createAliasSpeciesGlyph(getLayout(document, layoutIndex), speciesId, getReactionGlyph(document, layoutIndex, reactionId, reactionGlyphIndex)), updateCurves) {
+    if (!alias_element_createAliasSpeciesGlyph(getLayout(document, layoutIndex), speciesId, getReactionGlyph(document, layoutIndex, reactionId, reactionGlyphIndex))) {
         if (updateCurves) {
             return updateLayoutCurves(document, getLayout(document, layoutIndex));
         }
+
         return 0;
     }
+
     return -1;
 }
 

--- a/src/libsbmlnetwork_sbmldocument_layout.h
+++ b/src/libsbmlnetwork_sbmldocument_layout.h
@@ -94,8 +94,9 @@ LIBSBMLNETWORK_EXTERN int setUseNameAsTextLabel(SBMLDocument* document, unsigned
 /// @param speciesId the id of the Species to create an alias SpeciesGlyph for.
 /// @param reactionId the id of the Reaction to create an alias SpeciesGlyph for.
 /// @param reactionGlyphIndex the index of the ReactionGlyph object to create an alias SpeciesGlyph for.
+/// @param updateCurves whether to run autolayout after adding the glyph.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex);
+LIBSBMLNETWORK_EXTERN int createAliasSpeciesGlyph(SBMLDocument* document, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex, bool updateCurves = true);
 
 /// @brief Create an alias SpeciesGlyph object for Species with the given id and connect all the SpeciesReferences in the ReactionGlyph object with the given id and index that contain Species as a participant to the alias SpeciesGlyph in the Layout object with the given index in the ListOfLayouts of the SBMLDocument.
 /// @param document a pointer to the SBMLDocument object.
@@ -103,8 +104,9 @@ LIBSBMLNETWORK_EXTERN int createAliasSpeciesGlyph(SBMLDocument* document, const 
 /// @param speciesId the id of the Species to create an alias SpeciesGlyph for.
 /// @param reactionId the id of the Reaction to create an alias SpeciesGlyph for.
 /// @param reactionGlyphIndex the index of the ReactionGlyph object to create an alias SpeciesGlyph for.
+/// @param updateCurves whether to run autolayout after adding the glyph.
 /// @return integer value indicating success/failure of the function.
-LIBSBMLNETWORK_EXTERN int createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex);
+LIBSBMLNETWORK_EXTERN int createAliasSpeciesGlyph(SBMLDocument* document, unsigned int layoutIndex, const std::string& speciesId, const std::string& reactionId, unsigned int reactionGlyphIndex, bool updateCurves = true);
 
 /// @brief Creates an alias ReactionGlyph object for the Reaction with the given id in the first Layout object in the ListOfLayouts of the SBML document.
 /// @param document a pointer to the SBMLDocument object.


### PR DESCRIPTION
Loading a model into Antimony that had a lot of alias nodes was slow--this was why!