### PR TITLE
Fix #include so it works if included elsewhere.

### DIFF
--- a/src/features/styles/libsbmlnetwork_styles.h
+++ b/src/features/styles/libsbmlnetwork_styles.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 #include <map>
-#include "libsbmlnetwork_sbmldocument.h"
+#include "../../libsbmlnetwork_sbmldocument.h"
 
 namespace LIBSBMLNETWORK_CPP_NAMESPACE {
 


### PR DESCRIPTION
When I include this file in Antimony, it can't find the "libsbmlnetwork_sbmldocument.h" file unless I add the '../../' to it.